### PR TITLE
feat: validate authored registered custom property values

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Standalone tooling for validating CSS custom property registrations declared wit
 - Builds a registry from `@property` rules across multiple input files
 - Validates `syntax` descriptors in those registrations
 - Checks `var()` declaration values against the consuming CSS property, including coordinated multi-`var()` cases
+- Validates authored values assigned directly to registered custom properties
 - Ignores unregistered custom properties
 - Ships a standalone core package and a thin CLI wrapper
 
@@ -197,7 +198,7 @@ The validator assembles one registry from the full set of input files, then chec
 
 For this first cut, compatibility checks are intentionally conservative:
 
-- direct custom property assignments like `--token: 10px` are not validated yet
+- whitespace-toggle and similarly ambiguous custom property assignment patterns are skipped for now
 - automatic `@import` resolution is not implemented yet
 
 That keeps false positives down while the standalone core takes shape.

--- a/example.css
+++ b/example.css
@@ -74,6 +74,15 @@
 }
 
 /*
+  Valid authored assignments to registered custom properties should pass.
+*/
+:root {
+  --brand-color: rebeccapurple;
+  --space-md: 1.5rem;
+  --radius-lg: var(--space-md);
+}
+
+/*
   Invalid usages the validator should flag.
 */
 .card--broken {
@@ -86,6 +95,15 @@
   background-image: var(--brand-color);
   box-shadow: var(--space-md);
   aspect-ratio: var(--heading-font);
+}
+
+/*
+  Invalid authored assignments to registered custom properties should also be flagged.
+*/
+.theme-broken {
+  --brand-color: 10px;
+  --space-md: tomato;
+  --hero-image: var(--brand-color);
 }
 
 /*

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 CLI for CSS Property Type Validator.
 
-This package validates CSS `@property` registrations and checks whether registered custom properties are used compatibly through `var()`.
+This package validates CSS `@property` registrations, checks whether registered custom properties are used compatibly through `var()`, and validates authored assignments to registered custom properties.
 
 ## Install
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Core validation engine for CSS Property Type Validator.
 
-This package reads CSS `@property` registrations, builds a registry of typed custom properties, and validates compatible `var()` usage against consuming CSS properties.
+This package reads CSS `@property` registrations, builds a registry of typed custom properties, validates compatible `var()` usage against consuming CSS properties, and checks authored assignments to registered custom properties.
 
 ## Install
 
@@ -40,6 +40,8 @@ console.log(result.diagnostics);
 - Validates `@property` syntax descriptors
 - Builds a registry across provided input files
 - Validates single-`var()` declaration usages
-- Ignores unregistered custom properties in the current version
+- Validates authored values assigned to registered custom properties
+- Skips whitespace-toggle and similarly ambiguous custom property assignment patterns for now
+- Ignores unregistered custom properties
 
 Repository: [schalkneethling/css-property-type-validator](https://github.com/schalkneethling/css-property-type-validator)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,6 +26,7 @@ export interface RegisteredProperty {
 
 export type DiagnosticCode =
   | "invalid-property-registration"
+  | "incompatible-custom-property-assignment"
   | "incompatible-var-usage"
   | "unparseable-stylesheet";
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -24,6 +24,10 @@ function registryMap(registry: RegisteredProperty[]): Map<string, RegisteredProp
   return new Map(registry.map((entry) => [entry.name, entry]));
 }
 
+function isCustomPropertyName(propertyName: string): boolean {
+  return propertyName.startsWith("--");
+}
+
 function collectVarFunctions(value: any): any[] {
   const functions: any[] = [];
 
@@ -39,6 +43,14 @@ function collectVarFunctions(value: any): any[] {
   return functions;
 }
 
+function getDeclarationValueForValidation(declaration: any): any | null {
+  if (isCustomPropertyName(declaration.property)) {
+    return parseValue(cssTree.generate(declaration.value));
+  }
+
+  return declaration.value;
+}
+
 function getVarPropertyName(node: any): string | undefined {
   const firstNode = node.children?.first ?? node.children?.[0];
   return firstNode?.type === "Identifier" ? firstNode.name : undefined;
@@ -52,11 +64,21 @@ function parseValue(value: string): any | null {
   }
 }
 
-function declarationMatchesSamples(
-  declaration: any,
+function matchRegisteredSyntax(registration: RegisteredProperty, value: any): boolean {
+  if (registration.syntax === "*") {
+    return true;
+  }
+
+  const match = cssTree.lexer.match(registration.syntax, value);
+  return Boolean(match?.matched);
+}
+
+function valueMatchesSamples(
+  value: any,
   substitutions: Array<{ sample: string; varNode: any }>,
+  matcher: (candidateValue: any) => boolean,
 ): boolean {
-  const valueSource = cssTree.generate(declaration.value);
+  const valueSource = cssTree.generate(value);
   const replacedSource = substitutions.reduce((source, substitution) => {
     const replacementTarget = cssTree.generate(substitution.varNode);
     return source.replace(replacementTarget, substitution.sample);
@@ -67,8 +89,7 @@ function declarationMatchesSamples(
     return false;
   }
 
-  const match = cssTree.lexer.matchProperty(declaration.property, replacedAst);
-  return Boolean(match?.matched);
+  return matcher(replacedAst);
 }
 
 function toVarDiagnostic(
@@ -107,20 +128,37 @@ function toVarDiagnostic(
   };
 }
 
-function isCompatibleWithSubstitutions(
+function toAssignmentDiagnostic(
+  filePath: string,
   declaration: any,
+  registration: RegisteredProperty,
+): ValidationDiagnostic {
+  return {
+    code: "incompatible-custom-property-assignment",
+    filePath,
+    loc: toLocation(declaration.value.loc ?? declaration.loc),
+    message: `Assigned value for registered property ${registration.name} does not match its syntax "${registration.syntax}".`,
+    propertyName: registration.name,
+    registeredSyntax: registration.syntax,
+    snippet: cssTree.generate(declaration),
+  };
+}
+
+function isCompatibleWithSubstitutions(
+  value: any,
   substitutionOptions: Array<{ samples: string[]; varNode: any }>,
+  matcher: (candidateValue: any) => boolean,
   index = 0,
   activeSubstitutions: Array<{ sample: string; varNode: any }> = [],
 ): boolean {
   if (index === substitutionOptions.length) {
-    return declarationMatchesSamples(declaration, activeSubstitutions);
+    return valueMatchesSamples(value, activeSubstitutions, matcher);
   }
 
   const option = substitutionOptions[index];
 
   return option.samples.some((sample) =>
-    isCompatibleWithSubstitutions(declaration, substitutionOptions, index + 1, [
+    isCompatibleWithSubstitutions(value, substitutionOptions, matcher, index + 1, [
       ...activeSubstitutions,
       { sample, varNode: option.varNode },
     ]),
@@ -133,10 +171,39 @@ function validateDeclaration(
   registry: Map<string, RegisteredProperty>,
 ): { diagnostics: ValidationDiagnostic[]; skipped: number; validated: number } {
   const diagnostics: ValidationDiagnostic[] = [];
-  const varFunctions = collectVarFunctions(declaration.value);
+  const valueToValidate = getDeclarationValueForValidation(declaration);
 
-  // v1 only validates var() consumption sites, not authored values assigned to custom properties.
-  if (varFunctions.length === 0 || declaration.property.startsWith("--")) {
+  if (!valueToValidate) {
+    return isCustomPropertyName(declaration.property)
+      ? { diagnostics, skipped: 1, validated: 0 }
+      : { diagnostics, skipped: 0, validated: 0 };
+  }
+
+  const varFunctions = collectVarFunctions(valueToValidate);
+
+  if (isCustomPropertyName(declaration.property)) {
+    const registration = registry.get(declaration.property);
+
+    if (!registration) {
+      return { diagnostics, skipped: 0, validated: 0 };
+    }
+
+    const authoredValue = cssTree.generate(declaration.value).trim();
+
+    if (authoredValue.length === 0) {
+      return { diagnostics, skipped: 1, validated: 0 };
+    }
+
+    if (varFunctions.length === 0) {
+      if (!matchRegisteredSyntax(registration, valueToValidate)) {
+        diagnostics.push(toAssignmentDiagnostic(filePath, declaration, registration));
+      }
+
+      return { diagnostics, skipped: 0, validated: 1 };
+    }
+  }
+
+  if (varFunctions.length === 0) {
     return { diagnostics, skipped: 0, validated: 0 };
   }
 
@@ -164,6 +231,12 @@ function validateDeclaration(
       varNode: any;
     } => Boolean(entry.registration),
   );
+
+  if (isCustomPropertyName(declaration.property)) {
+    if (registeredEntries.length !== varMetadata.length) {
+      return { diagnostics, skipped: 1, validated: 0 };
+    }
+  }
 
   // Unregistered custom properties are intentionally ignored when no registered inputs participate.
   if (registeredEntries.length === 0) {
@@ -197,19 +270,33 @@ function validateDeclaration(
     });
   }
 
+  const matcher = isCustomPropertyName(declaration.property)
+    ? (candidateValue: any) =>
+        matchRegisteredSyntax(registry.get(declaration.property) as RegisteredProperty, candidateValue)
+    : (candidateValue: any) => {
+        const match = cssTree.lexer.matchProperty(declaration.property, candidateValue);
+        return Boolean(match?.matched);
+      };
+
   // The declaration passes if all registered var() usages can be substituted
   // with one compatible combination of representative sample values.
-  const isCompatible = isCompatibleWithSubstitutions(declaration, substitutionOptions);
+  const isCompatible = isCompatibleWithSubstitutions(valueToValidate, substitutionOptions, matcher);
 
   if (!isCompatible) {
-    diagnostics.push(
-      toVarDiagnostic(
-        filePath,
-        declaration,
-        registeredEntries.map((entry) => entry.registration),
-        registeredEntries.map((entry) => entry.varNode),
-      ),
-    );
+    if (isCustomPropertyName(declaration.property)) {
+      diagnostics.push(
+        toAssignmentDiagnostic(filePath, declaration, registry.get(declaration.property) as RegisteredProperty),
+      );
+    } else {
+      diagnostics.push(
+        toVarDiagnostic(
+          filePath,
+          declaration,
+          registeredEntries.map((entry) => entry.registration),
+          registeredEntries.map((entry) => entry.varNode),
+        ),
+      );
+    }
   }
 
   return { diagnostics, skipped: 0, validated: 1 };

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -92,15 +92,91 @@ describe("validateFiles", () => {
     expect(result.diagnostics[0]?.expectedProperty).toBe("color");
   });
 
-  it("ignores direct custom property assignments in the current version", () => {
+  it("accepts compatible direct assignments to registered custom properties", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+      "/tmp/usage.css": ":root { --brand-color: rebeccapurple; }",
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("reports incompatible direct assignments to registered custom properties", () => {
     const result = runValidation({
       "/tmp/registry.css":
         '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
       "/tmp/usage.css": ":root { --brand-color: 10px; }",
     });
 
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-custom-property-assignment");
+    expect(result.diagnostics[0]?.propertyName).toBe("--brand-color");
+    expect(result.diagnostics[0]?.expectedProperty).toBeUndefined();
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("accepts compatible assignment-site var() usage for registered custom properties", () => {
+    const result = runValidation({
+      "/tmp/registry.css": [
+        '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+        '@property --accent-color { syntax: "<color>"; inherits: true; initial-value: black; }',
+      ].join("\n"),
+      "/tmp/usage.css": ":root { --accent-color: var(--brand-color); }",
+    });
+
     expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("reports incompatible assignment-site var() usage for registered custom properties", () => {
+    const result = runValidation({
+      "/tmp/registry.css": [
+        '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+        '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+      ].join("\n"),
+      "/tmp/usage.css": ":root { --space: var(--brand-color); }",
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-custom-property-assignment");
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("skips assignment-site validation when var() references are mixed registered and unregistered", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+      "/tmp/usage.css": ":root { --space: var(--unknown-space); }",
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.skippedDeclarations).toBe(1);
     expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it("skips whitespace-only assignment-site declarations for the conservative MVP", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --space-toggle { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+      "/tmp/usage.css": ":root { --space-toggle: ; }",
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.skippedDeclarations).toBe(1);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it('accepts direct assignments for registered custom properties using syntax "*"', () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --anything { syntax: "*"; inherits: false; initial-value: 0px; }',
+      "/tmp/usage.css": ':root { --anything: clamp(1rem, 2vw, 3rem); }',
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(1);
   });
 
   it("accepts registered var() usages that include fallbacks in realistic component code", () => {
@@ -252,13 +328,24 @@ describe("validateFiles", () => {
       validatedDeclarations: number;
     };
 
-    expect(report.diagnostics).toHaveLength(12);
-    expect(report.diagnostics.every((diagnostic) => diagnostic.code === "incompatible-var-usage")).toBe(
-      true,
-    );
+    expect(report.diagnostics).toHaveLength(15);
+    expect(
+      report.diagnostics.every(
+        (diagnostic) =>
+          diagnostic.code === "incompatible-var-usage" ||
+          diagnostic.code === "incompatible-custom-property-assignment",
+      ),
+    ).toBe(true);
     expect(report.diagnostics.some((diagnostic) => diagnostic.expectedProperty === "inline-size")).toBe(
       true,
     );
+    expect(
+      report.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === "incompatible-custom-property-assignment" &&
+          diagnostic.propertyName === "--brand-color",
+      ),
+    ).toBe(true);
     expect(
       report.diagnostics.some(
         (diagnostic) => diagnostic.snippet === "border:var(--brand-color) solid var(--brand-color)",
@@ -270,6 +357,6 @@ describe("validateFiles", () => {
       ),
     ).toBe(true);
     expect(report.skippedDeclarations).toBe(0);
-    expect(report.validatedDeclarations).toBe(27);
+    expect(report.validatedDeclarations).toBe(33);
   });
 });


### PR DESCRIPTION
## Summary
- validate authored assignments to registered custom properties
- add assignment-site diagnostics and conservative skip behavior for unresolved or whitespace-only cases
- expand example.css and docs to cover the new validation behavior

## Testing
- pnpm test

## Notes
- Closes #5
- Follow-up fallback validation is tracked in #16