### PR TITLE
feat: Add registry input support to validator

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ console.log(result.diagnostics);
 ```bash
 css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
+css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 ```
 
 Human output is the default. The CLI exits with:
@@ -195,9 +196,18 @@ This example is truncated for readability. A full run against [example.css](/Use
 
 The validator assembles one registry from the full set of input files, then checks each stylesheet against that combined registry.
 
+When shared registrations live outside the files you want to validate, the CLI can add them as registry-only sources:
+
+```bash
+css-property-type-validator "src/components/**/*.css" --registry "src/tokens/**/*.css"
+```
+
+Registry-only files contribute `@property` registrations and any registration/parse diagnostics, but their own normal declarations are not validated unless you also pass them as main inputs.
+
 For this first cut, compatibility checks are intentionally conservative:
 
 - direct custom property assignments like `--token: 10px` are not validated yet
 - automatic `@import` resolution is not implemented yet
+- config-file based registry discovery is not implemented yet
 
 That keeps false positives down while the standalone core takes shape.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -21,7 +21,18 @@ npx @schalkneethling/css-property-type-validator-cli "src/**/*.css"
 ```bash
 css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
+css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 ```
+
+Use `--registry` multiple times to include shared `@property` definitions without validating the rest of those files:
+
+```bash
+css-property-type-validator "src/**/*.css" \
+  --registry "src/tokens/**/*.css" \
+  --registry "src/brand/**/*.css"
+```
+
+Registry-only files still report parse errors and invalid `@property` registrations. Automatic `@import` traversal is not supported yet.
 
 ## Exit codes
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -63,7 +63,9 @@ async function main(): Promise<void> {
       const inputs = await loadInputs(patterns);
 
       if (inputs.length === 0) {
-        process.stderr.write("No CSS files matched the provided patterns.\n");
+        process.stderr.write(
+          "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.\n",
+        );
         process.exitCode = 2;
         return;
       }

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -34,6 +34,16 @@ async function loadInputs(patterns: string[]): Promise<ValidationInput[]> {
   return inputs.sort((left, right) => left.path.localeCompare(right.path));
 }
 
+async function loadRegistryInputs(
+  patterns: string[],
+  validationInputs: ValidationInput[],
+): Promise<ValidationInput[]> {
+  const registryInputs = await loadInputs(patterns);
+  const validationPaths = new Set(validationInputs.map((input) => input.path));
+
+  return registryInputs.filter((input) => !validationPaths.has(input.path));
+}
+
 async function main(): Promise<void> {
   const program = new Command();
 
@@ -42,7 +52,13 @@ async function main(): Promise<void> {
     .description("Validate @property registrations and var() usages across CSS files.")
     .argument("<patterns...>", "CSS files or glob patterns to validate")
     .option("-f, --format <format>", "output format: human or json", "human")
-    .action(async (patterns: string[], options: { format: OutputFormat }) => {
+    .option(
+      "-r, --registry <pattern>",
+      "CSS file or glob pattern to use for shared @property registrations",
+      (value: string, previous: string[] = []) => [...previous, value],
+      [],
+    )
+    .action(async (patterns: string[], options: { format: OutputFormat; registry: string[] }) => {
       const format = options.format === "json" ? "json" : "human";
       const inputs = await loadInputs(patterns);
 
@@ -52,7 +68,8 @@ async function main(): Promise<void> {
         return;
       }
 
-      const result = validateFiles(inputs);
+      const registryInputs = await loadRegistryInputs(options.registry, inputs);
+      const result = validateFiles(inputs, { registryInputs });
       const output = formatValidationResult(result, format);
 
       process.stdout.write(`${output}\n`);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -15,22 +15,32 @@ pnpm add @schalkneethling/css-property-type-validator-core
 ```ts
 import { validateFiles } from "@schalkneethling/css-property-type-validator-core";
 
-const result = validateFiles([
+const result = validateFiles(
+  [
+    {
+      path: "example.css",
+      css: `
+        .card {
+          inline-size: var(--brand-color);
+        }
+      `,
+    },
+  ],
   {
-    path: "example.css",
-    css: `
-      @property --brand-color {
-        syntax: "<color>";
-        inherits: true;
-        initial-value: transparent;
-      }
-
-      .card {
-        inline-size: var(--brand-color);
-      }
-    `,
+    registryInputs: [
+      {
+        path: "tokens.css",
+        css: `
+          @property --brand-color {
+            syntax: "<color>";
+            inherits: true;
+            initial-value: transparent;
+          }
+        `,
+      },
+    ],
   },
-]);
+);
 
 console.log(result.diagnostics);
 ```
@@ -39,6 +49,7 @@ console.log(result.diagnostics);
 
 - Validates `@property` syntax descriptors
 - Builds a registry across provided input files
+- Can extend that registry with optional `registryInputs`
 - Validates single-`var()` declaration usages
 - Ignores unregistered custom properties in the current version
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,5 @@
 export { validateFiles } from "./validate.js";
+export type { ValidateFilesOptions } from "./validate.js";
 
 export type {
   RegisteredProperty,

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -10,6 +10,10 @@ import type {
   ValidationResult,
 } from "./types.js";
 
+export interface ValidateFilesOptions {
+  registryInputs?: ValidationInput[];
+}
+
 function toLocation(loc: any): ValidationDiagnostic["loc"] {
   return loc
     ? {
@@ -175,6 +179,14 @@ function validateDeclaration(
     return { diagnostics, skipped: 1, validated: 0 };
   }
 
+  // Universal-syntax registrations compute like unregistered custom properties,
+  // and we do not currently model authored custom-property values at computed value time.
+  // Skipping avoids false positives such as flagging `var(--token)` in places
+  // where the actual substituted value could still be valid.
+  if (registeredEntries.some((entry) => entry.registration.syntax === "*")) {
+    return { diagnostics, skipped: 1, validated: 0 };
+  }
+
   const substitutionOptions = [];
 
   for (const entry of registeredEntries) {
@@ -215,8 +227,24 @@ function validateDeclaration(
   return { diagnostics, skipped: 0, validated: 1 };
 }
 
-export function validateFiles(inputs: ValidationInput[]): ValidationResult {
-  const registryResult = collectRegistry(inputs);
+export function validateFiles(
+  inputs: ValidationInput[],
+  options: ValidateFilesOptions = {},
+): ValidationResult {
+  const registryInputs = options.registryInputs ?? [];
+  const registrySources = [...inputs];
+  const seenRegistryPaths = new Set(inputs.map((input) => input.path));
+
+  for (const input of registryInputs) {
+    if (seenRegistryPaths.has(input.path)) {
+      continue;
+    }
+
+    seenRegistryPaths.add(input.path);
+    registrySources.push(input);
+  }
+
+  const registryResult = collectRegistry(registrySources);
   const diagnostics = [...registryResult.diagnostics];
   const registry = registryMap(registryResult.registry);
   let skippedDeclarations = 0;

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -448,7 +448,7 @@ describe("validateFiles", () => {
     );
 
     expect(cliResult.status).toBe(2);
-    expect(cliResult.stderr).toContain("No CSS files matched the validation patterns. Files passed via --registry are registration sources only.");
+    expect(cliResult.stderr).toContain("No CSS files matched the validation patterns.");
   });
 
   it("includes registry-only diagnostics in CLI json output", { timeout: 120000 }, () => {

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -1,4 +1,6 @@
 import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import path from "node:path";
 
 import { describe, expect, it } from "vitest";
@@ -226,6 +228,110 @@ describe("validateFiles", () => {
     expect(result.skippedDeclarations).toBe(0);
   });
 
+  it("uses registry-only inputs to validate declarations in the main files", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { inline-size: var(--space); }" }],
+      {
+        registryInputs: [
+          {
+            path: "/tmp/registry.css",
+            css: '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(1);
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.filePath).toBe("/tmp/registry.css");
+  });
+
+  it("reports incompatible usage when the registration only exists in registry inputs", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { inline-size: var(--brand-color); }" }],
+      {
+        registryInputs: [
+          {
+            path: "/tmp/registry.css",
+            css: '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.diagnostics[0]?.expectedProperty).toBe("inline-size");
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("reports invalid registrations from registry-only inputs", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { color: var(--unknown-color, red); }" }],
+      {
+        registryInputs: [
+          {
+            path: "/tmp/registry.css",
+            css: '@property --bad { syntax: "<color"; inherits: true; initial-value: transparent; }',
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+  });
+
+  it("does not validate declarations that only appear in registry-only inputs", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { color: var(--brand-color); }" }],
+      {
+        registryInputs: [
+          {
+            path: "/tmp/registry.css",
+            css: [
+              '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+              ".tokens { inline-size: var(--brand-color); }",
+            ].join("\n"),
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(1);
+    expect(result.skippedDeclarations).toBe(0);
+  });
+
+  it("does not duplicate diagnostics when a file appears in both validation and registry inputs", () => {
+    const sharedInput = {
+      path: "/tmp/shared.css",
+      css: [
+        '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+        ".card { inline-size: var(--brand-color); }",
+      ].join("\n"),
+    };
+
+    const result = validateFiles([sharedInput], { registryInputs: [sharedInput] });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.registry).toHaveLength(1);
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("skips compatibility diagnostics for universal-syntax registrations", () => {
+    const result = runValidation({
+      "/tmp/registry.css": '@property --anything { syntax: "*"; inherits: false; }',
+      "/tmp/usage.css": ".card { color: var(--anything); }",
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.skippedDeclarations).toBe(1);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
   it("runs the example script as an end-to-end smoke test", { timeout: 120000 }, () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../..");
     const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
@@ -271,5 +377,118 @@ describe("validateFiles", () => {
     ).toBe(true);
     expect(report.skippedDeclarations).toBe(0);
     expect(report.validatedDeclarations).toBe(27);
+  });
+
+  it("supports registry-only CLI inputs", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const validationPath = path.join(fixtureDir, "component.css");
+    const registryPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(validationPath, ".card { inline-size: var(--space); }\n");
+    writeFileSync(
+      registryPath,
+      '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }\n',
+    );
+
+    const cliResult = spawnSync(
+      "node",
+      [
+        "packages/cli/dist/cli.js",
+        validationPath,
+        "--registry",
+        registryPath,
+        "--format",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(0);
+
+    const report = JSON.parse(cliResult.stdout) as {
+      diagnostics: Array<{ code: string }>;
+      registry: Array<{ filePath: string }>;
+      validatedDeclarations: number;
+    };
+
+    expect(report.diagnostics).toHaveLength(0);
+    expect(report.registry).toHaveLength(1);
+    expect(report.registry[0]?.filePath).toBe(registryPath);
+    expect(report.validatedDeclarations).toBe(1);
+  });
+
+  it("returns exit code 2 when only registry inputs match", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const registryPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(
+      registryPath,
+      '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }\n',
+    );
+
+    const cliResult = spawnSync(
+      "node",
+      [
+        "packages/cli/dist/cli.js",
+        path.join(fixtureDir, "missing-*.css"),
+        "--registry",
+        registryPath,
+        "--format",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(2);
+    expect(cliResult.stderr).toContain("No CSS files matched the provided patterns.");
+  });
+
+  it("includes registry-only diagnostics in CLI json output", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const validationPath = path.join(fixtureDir, "component.css");
+    const registryPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(validationPath, ".card { color: var(--unknown-color, red); }\n");
+    writeFileSync(
+      registryPath,
+      '@property --bad { syntax: "<color"; inherits: true; initial-value: transparent; }\n',
+    );
+
+    const cliResult = spawnSync(
+      "node",
+      [
+        "packages/cli/dist/cli.js",
+        validationPath,
+        "--registry",
+        registryPath,
+        "--format",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(1);
+
+    const report = JSON.parse(cliResult.stdout) as {
+      diagnostics: Array<{ code: string; filePath: string }>;
+      validatedDeclarations: number;
+    };
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(report.diagnostics[0]?.filePath).toBe(registryPath);
+    expect(report.validatedDeclarations).toBe(0);
   });
 });

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -283,7 +283,7 @@ describe("validateFiles", () => {
     expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
   });
 
-  it("does not validate declarations that only appear in registry-only inputs", () => {
+  it("treats registry-only files as registration sources, not validation targets", () => {
     const result = validateFiles(
       [{ path: "/tmp/component.css", css: ".card { color: var(--brand-color); }" }],
       {

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -247,7 +247,7 @@ describe("validateFiles", () => {
     expect(result.registry[0]?.filePath).toBe("/tmp/registry.css");
   });
 
-  it("reports incompatible usage when the registration only exists in registry inputs", () => {
+  it("ensures that an @property registration from external CSS validates local use", () => {
     const result = validateFiles(
       [{ path: "/tmp/component.css", css: ".card { inline-size: var(--brand-color); }" }],
       {

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -448,7 +448,7 @@ describe("validateFiles", () => {
     );
 
     expect(cliResult.status).toBe(2);
-    expect(cliResult.stderr).toContain("No CSS files matched the provided patterns.");
+    expect(cliResult.stderr).toContain("No CSS files matched the validation patterns. Files passed via --registry are registration sources only.");
   });
 
   it("includes registry-only diagnostics in CLI json output", { timeout: 120000 }, () => {

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -448,7 +448,9 @@ describe("validateFiles", () => {
     );
 
     expect(cliResult.status).toBe(2);
-    expect(cliResult.stderr).toContain("No CSS files matched the validation patterns.");
+    expect(cliResult.stderr).toContain(
+      "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.",
+    );
   });
 
   it("includes registry-only diagnostics in CLI json output", { timeout: 120000 }, () => {


### PR DESCRIPTION
## Summary
Add repeatable `--registry` inputs to the CLI and support split validation versus registry inputs in the core validator.

## What changed
- add a repeatable CLI `--registry <pattern>` option for shared `@property` files
- extend `validateFiles()` with optional `registryInputs` so registry assembly and validation inputs can differ
- keep registry-only files out of normal declaration validation while still reporting registration diagnostics
- skip compatibility diagnostics for `syntax: "*"` registrations until authored custom-property values are modeled at computed value time
- document the new registry flow in the root, CLI, and core READMEs
- add regression coverage for core and CLI registry-input behavior

## Why
Projects often keep `@property` registrations in shared token files that are distinct from the files being validated. Requiring every registration file to be passed as a normal validation target adds friction and can validate files the user did not intend to check.

## Validation
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test`

## Follow-up
- Closes #4
- Follow-up spec-alignment work is tracked in #21 and #22
