### PR TITLE
feat: Align @property registration validation with spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ pnpm install
 pnpm run typecheck
 pnpm test
 pnpm run build
+pnpm run check:supported-syntax-names
 ```
 
 ## CI and Releases

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "build": "pnpm -r --if-present run build",
     "test": "vp test run",
     "typecheck": "tsc -b tsconfig.json",
+    "check:supported-syntax-names": "node scripts/check-supported-syntax-names.mjs",
     "clean": "node scripts/clean.mjs",
     "example": "pnpm run build && node packages/cli/dist/cli.js example.css"
   },

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.6.0",
+    "cheerio": "^1.2.0",
     "typescript": "^6.0.2",
     "vite-plus": "^0.1.16"
   },

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -4,31 +4,27 @@ import { getUnsupportedSyntaxComponentName } from "./supported-syntax.js";
 
 import type { RegisteredProperty, ValidationDiagnostic, ValidationInput } from "./types.js";
 
-const COMPUTATION_INDEPENDENT_DIMENSION_UNITS = Object.freeze({
-  cm: true,
-  deg: true,
-  dpcm: true,
-  dpi: true,
-  dppx: true,
-  grad: true,
-  in: true,
-  ms: true,
-  mm: true,
-  pc: true,
-  pt: true,
-  px: true,
-  q: true,
-  rad: true,
-  s: true,
-  turn: true,
-  x: true,
-});
+const COMPUTATION_INDEPENDENT_DIMENSION_UNITS = Object.freeze([
+  "cm",
+  "deg",
+  "dpcm",
+  "dpi",
+  "dppx",
+  "grad",
+  "in",
+  "ms",
+  "mm",
+  "pc",
+  "pt",
+  "px",
+  "q",
+  "rad",
+  "s",
+  "turn",
+  "x",
+]);
 
-const COMPUTATION_DEPENDENT_FUNCTIONS = Object.freeze({
-  attr: true,
-  env: true,
-  var: true,
-});
+const COMPUTATION_DEPENDENT_FUNCTIONS = Object.freeze(["attr", "env", "var"]);
 
 function toBoolean(value: string | undefined): boolean | undefined {
   if (value === "true") {
@@ -92,7 +88,7 @@ function getComputationalIndependenceFailure(value: any): string | null {
         // Values that depend on later substitution, such as var(), are not computationally
         // independent. CSS Properties and Values API Level 1 §2.7 defines var() substitution:
         // https://www.w3.org/TR/css-properties-values-api-1/#substitution
-        if (Object.hasOwn(COMPUTATION_DEPENDENT_FUNCTIONS, functionName)) {
+        if (COMPUTATION_DEPENDENT_FUNCTIONS.includes(functionName)) {
           failure =
             functionName === "var"
               ? "uses var(), which makes the registration invalid because initial-value must be computationally independent"
@@ -105,7 +101,7 @@ function getComputationalIndependenceFailure(value: any): string | null {
       if (node.type === "Dimension") {
         const unit = String(node.unit ?? "").toLowerCase();
 
-        if (!Object.hasOwn(COMPUTATION_INDEPENDENT_DIMENSION_UNITS, unit)) {
+        if (!COMPUTATION_INDEPENDENT_DIMENSION_UNITS.includes(unit)) {
           failure =
             `uses the relative or context-dependent unit "${node.unit}", which makes the registration invalid because initial-value must be computationally independent`;
         }

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -135,10 +135,10 @@ function validateInitialValueAgainstSyntax(
     return `@property ${propertyName} has an initial-value that could not be parsed as a CSS value.`;
   }
 
-  const independenceFailure = getComputationalIndependenceFailureReason(parsedValue);
+  const independenceFailureReason = getComputationalIndependenceFailureReason(parsedValue);
 
-  if (independenceFailure) {
-    return `@property ${propertyName} has an initial-value "${initialValue}" that ${independenceFailure}.`;
+  if (independenceFailureReason) {
+    return `@property ${propertyName} has an initial-value "${initialValue}" that ${independenceFailureReason}.`;
   }
 
   const match = cssTree.lexer.match(syntax, parsedValue);

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -75,7 +75,7 @@ function isAbsoluteUrl(url: string): boolean {
   }
 }
 
-function getComputationalIndependenceFailure(value: any): string | null {
+function getComputationalIndependenceFailureReason(value: any): string | null {
   let failure: string | null = null;
 
   cssTree.walk(value, {
@@ -135,7 +135,7 @@ function validateInitialValueAgainstSyntax(
     return `@property ${propertyName} has an initial-value that could not be parsed as a CSS value.`;
   }
 
-  const independenceFailure = getComputationalIndependenceFailure(parsedValue);
+  const independenceFailure = getComputationalIndependenceFailureReason(parsedValue);
 
   if (independenceFailure) {
     return `@property ${propertyName} has an initial-value "${initialValue}" that ${independenceFailure}.`;

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,6 +1,34 @@
 import * as cssTree from "css-tree";
 
+import { getUnsupportedSyntaxComponentName } from "./supported-syntax.js";
+
 import type { RegisteredProperty, ValidationDiagnostic, ValidationInput } from "./types.js";
+
+const COMPUTATION_INDEPENDENT_DIMENSION_UNITS = Object.freeze({
+  cm: true,
+  deg: true,
+  dpcm: true,
+  dpi: true,
+  dppx: true,
+  grad: true,
+  in: true,
+  ms: true,
+  mm: true,
+  pc: true,
+  pt: true,
+  px: true,
+  q: true,
+  rad: true,
+  s: true,
+  turn: true,
+  x: true,
+});
+
+const COMPUTATION_DEPENDENT_FUNCTIONS = Object.freeze({
+  attr: true,
+  env: true,
+  var: true,
+});
 
 function toBoolean(value: string | undefined): boolean | undefined {
   if (value === "true") {
@@ -32,6 +60,96 @@ function descriptorMap(block: any): Map<string, any> {
   }
 
   return descriptors;
+}
+
+function parseValue(value: string): any | null {
+  try {
+    return cssTree.parse(value, { context: "value" });
+  } catch {
+    return null;
+  }
+}
+
+function isAbsoluteUrl(url: string): boolean {
+  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+}
+
+function getComputationalIndependenceFailure(value: any): string | null {
+  let failure: string | null = null;
+
+  cssTree.walk(value, {
+    enter(node: any) {
+      if (failure) {
+        return;
+      }
+
+      if (node.type === "Function") {
+        const functionName = String(node.name ?? "").toLowerCase();
+
+        // CSS Properties and Values API Level 1 §3.3 requires non-universal initial-value
+        // descriptors to be computationally independent:
+        // https://www.w3.org/TR/css-properties-values-api-1/#initial-value-descriptor
+        // Values that depend on later substitution, such as var(), are not computationally
+        // independent. CSS Properties and Values API Level 1 §2.7 defines var() substitution:
+        // https://www.w3.org/TR/css-properties-values-api-1/#substitution
+        if (Object.hasOwn(COMPUTATION_DEPENDENT_FUNCTIONS, functionName)) {
+          failure =
+            functionName === "var"
+              ? "uses var(), which makes the registration invalid because initial-value must be computationally independent"
+              : `uses ${functionName}(), which makes the registration invalid because initial-value must be computationally independent`;
+        }
+
+        return;
+      }
+
+      if (node.type === "Dimension") {
+        const unit = String(node.unit ?? "").toLowerCase();
+
+        if (!Object.hasOwn(COMPUTATION_INDEPENDENT_DIMENSION_UNITS, unit)) {
+          failure =
+            `uses the relative or context-dependent unit "${node.unit}", which makes the registration invalid because initial-value must be computationally independent`;
+        }
+
+        return;
+      }
+
+      if (node.type === "Url" && !isAbsoluteUrl(String(node.value ?? ""))) {
+        failure =
+          "uses a relative URL, which makes the registration invalid because initial-value must be computationally independent";
+      }
+    },
+  });
+
+  return failure;
+}
+
+function validateInitialValueAgainstSyntax(
+  propertyName: string,
+  syntax: string,
+  initialValue: string,
+): string | null {
+  const parsedValue = parseValue(initialValue);
+
+  if (!parsedValue) {
+    return `@property ${propertyName} has an initial-value that could not be parsed as a CSS value.`;
+  }
+
+  const independenceFailure = getComputationalIndependenceFailure(parsedValue);
+
+  if (independenceFailure) {
+    return `@property ${propertyName} has an initial-value "${initialValue}" that ${independenceFailure}.`;
+  }
+
+  const match = cssTree.lexer.match(syntax, parsedValue);
+
+  // CSS Properties and Values API Level 1 §3.3 requires non-universal initial-value
+  // values to parse according to the declared syntax:
+  // https://www.w3.org/TR/css-properties-values-api-1/#initial-value-descriptor
+  if (!match?.matched) {
+    return `@property ${propertyName} has an initial-value "${initialValue}" that does not match its syntax descriptor "${syntax}".`;
+  }
+
+  return null;
 }
 
 function getStringDescriptor(declaration: any): string | undefined {
@@ -100,6 +218,10 @@ export function collectRegistry(inputs: ValidationInput[]): {
         const descriptors = descriptorMap(node.block);
         const syntaxDeclaration = descriptors.get("syntax");
         const syntax = getStringDescriptor(syntaxDeclaration);
+        const inheritsDescriptor = descriptors.get("inherits");
+        const inheritsRaw = getRawDescriptor(inheritsDescriptor);
+        const inherits = toBoolean(inheritsRaw);
+        const initialValue = getRawDescriptor(descriptors.get("initial-value"));
 
         if (!syntax) {
           diagnostics.push({
@@ -112,9 +234,11 @@ export function collectRegistry(inputs: ValidationInput[]): {
           return;
         }
 
+        let syntaxAst: any;
+
         try {
           if (syntax !== "*") {
-            cssTree.definitionSyntax.parse(syntax);
+            syntaxAst = cssTree.definitionSyntax.parse(syntax);
           }
         } catch (error) {
           diagnostics.push({
@@ -128,10 +252,96 @@ export function collectRegistry(inputs: ValidationInput[]): {
           return;
         }
 
+        if (syntax !== "*") {
+          // CSS Properties and Values API Level 1 §5.4.4 only accepts supported syntax
+          // component names from §5.1:
+          // https://www.w3.org/TR/css-properties-values-api-1/#supported-names
+          const unsupportedName = getUnsupportedSyntaxComponentName(syntaxAst);
+
+          if (unsupportedName) {
+            diagnostics.push({
+              code: "invalid-property-registration",
+              filePath: input.path,
+              loc: toLocation(node.loc),
+              message: `@property ${propertyName} uses the unsupported syntax component name "${unsupportedName}".`,
+              propertyName,
+              registeredSyntax: syntax,
+            });
+            return;
+          }
+        }
+
+        // Unknown descriptors are intentionally ignored and do not invalidate the
+        // @property rule. We only validate the known descriptors defined by the spec.
+        // CSS Properties and Values API Level 1 §3:
+        // https://www.w3.org/TR/css-properties-values-api-1/#at-property-rule
+
+        if (!inheritsDescriptor) {
+          diagnostics.push({
+            code: "invalid-property-registration",
+            filePath: input.path,
+            loc: toLocation(node.loc),
+            message: `@property ${propertyName} is missing the required inherits descriptor.`,
+            propertyName,
+            registeredSyntax: syntax,
+          });
+          return;
+        }
+
+        if (inherits === undefined) {
+          diagnostics.push({
+            code: "invalid-property-registration",
+            filePath: input.path,
+            loc: toLocation(node.loc),
+            message: `@property ${propertyName} must set inherits to true or false.`,
+            propertyName,
+            registeredSyntax: syntax,
+          });
+          return;
+        }
+
+        // CSS Properties and Values API Level 1 §3.3 only allows omitted initial-value
+        // when the syntax is the universal syntax definition:
+        // https://www.w3.org/TR/css-properties-values-api-1/#initial-value-descriptor
+        if (syntax !== "*" && !initialValue) {
+          diagnostics.push({
+            code: "invalid-property-registration",
+            filePath: input.path,
+            loc: toLocation(node.loc),
+            message: `@property ${propertyName} is missing the required initial-value descriptor for non-universal syntax "${syntax}".`,
+            propertyName,
+            registeredSyntax: syntax,
+          });
+          return;
+        }
+
+        if (syntax !== "*" && initialValue) {
+          const initialValueFailure = validateInitialValueAgainstSyntax(
+            propertyName,
+            syntax,
+            initialValue,
+          );
+
+          if (initialValueFailure) {
+            diagnostics.push({
+              code: "invalid-property-registration",
+              filePath: input.path,
+              loc: toLocation(node.loc),
+              message: initialValueFailure,
+              propertyName,
+              registeredSyntax: syntax,
+            });
+            return;
+          }
+        }
+
+        // CSS Properties and Values API Level 1 §2.1 says the last valid registration in
+        // document order wins. Invalid later rules must not displace an earlier valid one:
+        // https://www.w3.org/TR/css-properties-values-api-1/#determining-registration
         registry.set(propertyName, {
           filePath: input.path,
-          inherits: toBoolean(getRawDescriptor(descriptors.get("inherits"))),
-          initialValue: getRawDescriptor(descriptors.get("initial-value")),
+          inherits,
+          initialValue,
           loc: toLocation(node.loc),
           name: propertyName,
           syntax,

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -276,7 +276,6 @@ export function collectRegistry(inputs: ValidationInput[]): {
         // @property rule. We only validate the known descriptors defined by the spec.
         // CSS Properties and Values API Level 1 §3:
         // https://www.w3.org/TR/css-properties-values-api-1/#at-property-rule
-
         if (!inheritsDescriptor) {
           diagnostics.push({
             code: "invalid-property-registration",

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,6 +1,6 @@
 import * as cssTree from "css-tree";
 
-import { getUnsupportedSyntaxComponentName } from "./supported-syntax.js";
+import { getFirstUnsupportedSyntaxComponentName } from "./supported-syntax.js";
 
 import type { RegisteredProperty, ValidationDiagnostic, ValidationInput } from "./types.js";
 
@@ -257,7 +257,7 @@ export function collectRegistry(inputs: ValidationInput[]): {
           // CSS Properties and Values API Level 1 §5.4.4 only accepts supported syntax
           // component names from §5.1:
           // https://www.w3.org/TR/css-properties-values-api-1/#supported-names
-          const unsupportedName = getUnsupportedSyntaxComponentName(syntaxAst);
+          const unsupportedName = getFirstUnsupportedSyntaxComponentName(syntaxAst);
 
           if (unsupportedName) {
             diagnostics.push({

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -67,7 +67,12 @@ function parseValue(value: string): any | null {
 }
 
 function isAbsoluteUrl(url: string): boolean {
-  return /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(url);
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function getComputationalIndependenceFailure(value: any): string | null {

--- a/packages/core/src/supported-syntax.ts
+++ b/packages/core/src/supported-syntax.ts
@@ -18,11 +18,7 @@ export const SUPPORTED_SYNTAX_COMPONENT_NAMES = Object.freeze([
   "<transform-function>",
   "<custom-ident>",
   "<transform-list>",
-] as const);
-
-const SUPPORTED_SYNTAX_COMPONENT_NAME_LOOKUP = Object.freeze(
-  Object.fromEntries(SUPPORTED_SYNTAX_COMPONENT_NAMES.map((name) => [name, true] as const)),
-);
+] as readonly string[]);
 
 function validateNode(node: any): string | null {
   if (!node) {
@@ -46,9 +42,7 @@ function validateNode(node: any): string | null {
 
     case "Type": {
       const supportedName = `<${node.name}>`;
-      return Object.hasOwn(SUPPORTED_SYNTAX_COMPONENT_NAME_LOOKUP, supportedName)
-        ? null
-        : supportedName;
+      return SUPPORTED_SYNTAX_COMPONENT_NAMES.includes(supportedName) ? null : supportedName;
     }
 
     case "Keyword":

--- a/packages/core/src/supported-syntax.ts
+++ b/packages/core/src/supported-syntax.ts
@@ -1,0 +1,64 @@
+// CSS Properties and Values API Level 1 §5.1 defines the supported syntax component
+// names that can appear as data type names inside a syntax string:
+// https://www.w3.org/TR/css-properties-values-api-1/#supported-names
+// This frozen list is intentionally maintained from the published spec and checked by
+// tests and the advisory verification script instead of being discovered dynamically.
+export const SUPPORTED_SYNTAX_COMPONENT_NAMES = Object.freeze([
+  "<length>",
+  "<number>",
+  "<percentage>",
+  "<length-percentage>",
+  "<color>",
+  "<image>",
+  "<url>",
+  "<integer>",
+  "<angle>",
+  "<time>",
+  "<resolution>",
+  "<transform-function>",
+  "<custom-ident>",
+  "<transform-list>",
+] as const);
+
+const SUPPORTED_SYNTAX_COMPONENT_NAME_LOOKUP = Object.freeze(
+  Object.fromEntries(SUPPORTED_SYNTAX_COMPONENT_NAMES.map((name) => [name, true] as const)),
+);
+
+function validateNode(node: any): string | null {
+  if (!node) {
+    return null;
+  }
+
+  switch (node.type) {
+    case "Group":
+      for (const term of node.terms ?? []) {
+        const unsupportedName = validateNode(term);
+
+        if (unsupportedName) {
+          return unsupportedName;
+        }
+      }
+
+      return null;
+
+    case "Multiplier":
+      return validateNode(node.term);
+
+    case "Type": {
+      const supportedName = `<${node.name}>`;
+      return Object.hasOwn(SUPPORTED_SYNTAX_COMPONENT_NAME_LOOKUP, supportedName)
+        ? null
+        : supportedName;
+    }
+
+    case "Keyword":
+      return null;
+
+    default:
+      return null;
+  }
+}
+
+export function getUnsupportedSyntaxComponentName(syntaxAst: any): string | null {
+  return validateNode(syntaxAst);
+}

--- a/packages/core/src/supported-syntax.ts
+++ b/packages/core/src/supported-syntax.ts
@@ -59,6 +59,6 @@ function validateNode(node: any): string | null {
   }
 }
 
-export function getUnsupportedSyntaxComponentName(syntaxAst: any): string | null {
+export function getFirstUnsupportedSyntaxComponentName(syntaxAst: any): string | null {
   return validateNode(syntaxAst);
 }

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -78,6 +78,131 @@ describe("validateFiles", () => {
     expect(result.diagnostics[0]?.message).toContain("missing a valid string-valued syntax");
   });
 
+  it("reports missing inherits descriptors in @property rules", () => {
+    const result = runValidation({
+      "/tmp/registry.css": '@property --space { syntax: "<length>"; initial-value: 0px; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.message).toContain("missing the required inherits descriptor");
+    expect(result.registry).toHaveLength(0);
+  });
+
+  it("reports invalid inherits values in @property rules", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --space { syntax: "<length>"; inherits: maybe; initial-value: 0px; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.message).toContain("must set inherits to true or false");
+    expect(result.registry).toHaveLength(0);
+  });
+
+  it("reports missing initial-value descriptors for non-universal syntax", () => {
+    const result = runValidation({
+      "/tmp/registry.css": '@property --space { syntax: "<length>"; inherits: false; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.message).toContain("missing the required initial-value descriptor");
+    expect(result.registry).toHaveLength(0);
+  });
+
+  it('allows omitted initial-value descriptors for syntax "*"', () => {
+    const result = runValidation({
+      "/tmp/registry.css": '@property --anything { syntax: "*"; inherits: false; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.syntax).toBe("*");
+  });
+
+  it("reports initial-value values that do not match the declared syntax", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: 10px; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.message).toContain('does not match its syntax descriptor "<color>"');
+    expect(result.registry).toHaveLength(0);
+  });
+
+  it("reports non-computationally-independent initial-value units", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --space { syntax: "<length>"; inherits: false; initial-value: 3em; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.message).toContain('uses the relative or context-dependent unit "em"');
+    expect(result.registry).toHaveLength(0);
+  });
+
+  it("reports initial-value values that use var()", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --space { syntax: "<length>"; inherits: false; initial-value: var(--token); }',
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.message).toContain("uses var()");
+    expect(result.registry).toHaveLength(0);
+  });
+
+  it("ignores unknown descriptors when the known descriptors are valid", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; design-token-group: spacing; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.name).toBe("--space");
+  });
+
+  it("rejects unsupported syntax component names", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --space { syntax: "<foo>"; inherits: false; initial-value: bar; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.message).toContain('unsupported syntax component name "<foo>"');
+    expect(result.registry).toHaveLength(0);
+  });
+
+  it("accepts supported pre-multiplied syntax component names", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --transforms { syntax: "<transform-list>"; inherits: false; initial-value: rotate(45deg); }',
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.syntax).toBe("<transform-list>");
+  });
+
+  it("accepts syntax strings that use custom identifiers", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --size-name { syntax: "big | bigger | BIGGER"; inherits: false; initial-value: big; }',
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.syntax).toBe("big | bigger | BIGGER");
+  });
+
   it("uses the latest collected registration when the same custom property is declared in multiple files", () => {
     const result = runValidation({
       "/tmp/tokens-base.css":
@@ -92,6 +217,22 @@ describe("validateFiles", () => {
     expect(result.registry[0]?.syntax).toBe("<length>");
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.expectedProperty).toBe("color");
+  });
+
+  it("keeps the last valid registration when a later registration is invalid", () => {
+    const result = runValidation({
+      "/tmp/tokens-base.css":
+        '@property --surface-token { syntax: "<color>"; inherits: true; initial-value: white; }',
+      "/tmp/tokens-theme.css":
+        '@property --surface-token { syntax: "<length>"; inherits: false; initial-value: 3em; }',
+      "/tmp/component.css": ".card { color: var(--surface-token); }",
+    });
+
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.filePath).toBe("/tmp/tokens-base.css");
+    expect(result.registry[0]?.syntax).toBe("<color>");
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
   });
 
   it("accepts compatible direct assignments to registered custom properties", () => {
@@ -429,22 +570,30 @@ describe("validateFiles", () => {
     expect(cliResult.status).toBe(1);
 
     const report = JSON.parse(cliResult.stdout) as {
-      diagnostics: Array<{ code: string; expectedProperty?: string; snippet?: string }>;
+      diagnostics: Array<{
+        code: string;
+        expectedProperty?: string;
+        propertyName?: string;
+        snippet?: string;
+      }>;
       skippedDeclarations: number;
       validatedDeclarations: number;
     };
 
-    expect(report.diagnostics).toHaveLength(15);
-    expect(
-      report.diagnostics.every(
-        (diagnostic) =>
-          diagnostic.code === "incompatible-var-usage" ||
-          diagnostic.code === "incompatible-custom-property-assignment",
-      ),
-    ).toBe(true);
+    expect(report.diagnostics).toHaveLength(13);
+    expect(report.diagnostics.some((diagnostic) => diagnostic.code === "invalid-property-registration")).toBe(
+      true,
+    );
     expect(report.diagnostics.some((diagnostic) => diagnostic.expectedProperty === "inline-size")).toBe(
       true,
     );
+    expect(
+      report.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.code === "invalid-property-registration" &&
+          diagnostic.propertyName === "--space-md",
+      ),
+    ).toBe(true);
     expect(
       report.diagnostics.some(
         (diagnostic) =>
@@ -462,8 +611,8 @@ describe("validateFiles", () => {
         (diagnostic) => diagnostic.snippet === "margin-inline:var(--brand-color) var(--radius-lg)",
       ),
     ).toBe(true);
-    expect(report.skippedDeclarations).toBe(0);
-    expect(report.validatedDeclarations).toBe(33);
+    expect(report.skippedDeclarations).toBe(4);
+    expect(report.validatedDeclarations).toBe(15);
   });
 
   it("supports registry-only CLI inputs", { timeout: 120000 }, () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/node':
         specifier: ^25.6.0
         version: 25.6.0
+      cheerio:
+        specifier: ^1.2.0
+        version: 1.2.0
       typescript:
         specifier: ^6.0.2
         version: 6.0.2
@@ -630,9 +633,19 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  boolbase@1.0.0:
+    resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
+
   chai@6.2.2:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
+
+  cheerio-select@2.1.0:
+    resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
+
+  cheerio@1.2.0:
+    resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
+    engines: {node: '>=20.18.1'}
 
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
@@ -641,13 +654,48 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  css-select@5.2.2:
+    resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
+
   css-tree@3.2.1:
     resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
+  css-what@6.2.2:
+    resolution: {integrity: sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==}
+    engines: {node: '>= 6'}
+
   detect-libc@2.1.2:
     resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
     engines: {node: '>=8'}
+
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  encoding-sniffer@0.2.1:
+    resolution: {integrity: sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==}
+
+  entities@4.5.0:
+    resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
+
+  entities@7.0.1:
+    resolution: {integrity: sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==}
+    engines: {node: '>=0.12'}
 
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
@@ -675,6 +723,13 @@ packages:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
     os: [darwin]
+
+  htmlparser2@10.1.0:
+    resolution: {integrity: sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -765,6 +820,9 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nth-check@2.1.1:
+    resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
+
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
@@ -786,6 +844,15 @@ packages:
     peerDependenciesMeta:
       oxlint-tsgolint:
         optional: true
+
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    resolution: {integrity: sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==}
+
+  parse5-parser-stream@7.1.2:
+    resolution: {integrity: sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -813,6 +880,9 @@ packages:
     resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
@@ -864,6 +934,10 @@ packages:
 
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
+
+  undici@7.25.0:
+    resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
+    engines: {node: '>=20.18.1'}
 
   vite-plus@0.1.16:
     resolution: {integrity: sha512-sgYHc5zWLSDInaHb/abvEA7UOwh7sUWuyNt+Slphj55jPvzodT8Dqw115xyKwDARTuRFSpm1eo/t58qZ8/NylQ==}
@@ -953,6 +1027,15 @@ packages:
         optional: true
       jsdom:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
 
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
@@ -1327,18 +1410,82 @@ snapshots:
 
   assertion-error@2.0.1: {}
 
+  boolbase@1.0.0: {}
+
   chai@6.2.2: {}
+
+  cheerio-select@2.1.0:
+    dependencies:
+      boolbase: 1.0.0
+      css-select: 5.2.2
+      css-what: 6.2.2
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+
+  cheerio@1.2.0:
+    dependencies:
+      cheerio-select: 2.1.0
+      dom-serializer: 2.0.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      encoding-sniffer: 0.2.1
+      htmlparser2: 10.1.0
+      parse5: 7.3.0
+      parse5-htmlparser2-tree-adapter: 7.1.0
+      parse5-parser-stream: 7.1.2
+      undici: 7.25.0
+      whatwg-mimetype: 4.0.0
 
   commander@14.0.3: {}
 
   convert-source-map@2.0.0: {}
+
+  css-select@5.2.2:
+    dependencies:
+      boolbase: 1.0.0
+      css-what: 6.2.2
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      nth-check: 2.1.1
 
   css-tree@3.2.1:
     dependencies:
       mdn-data: 2.27.1
       source-map-js: 1.2.1
 
+  css-what@6.2.2: {}
+
   detect-libc@2.1.2: {}
+
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  encoding-sniffer@0.2.1:
+    dependencies:
+      iconv-lite: 0.6.3
+      whatwg-encoding: 3.1.1
+
+  entities@4.5.0: {}
+
+  entities@6.0.1: {}
+
+  entities@7.0.1: {}
 
   es-module-lexer@1.7.0: {}
 
@@ -1356,6 +1503,17 @@ snapshots:
 
   fsevents@2.3.3:
     optional: true
+
+  htmlparser2@10.1.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 7.0.1
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -1416,6 +1574,10 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nth-check@2.1.1:
+    dependencies:
+      boolbase: 1.0.0
+
   obug@2.1.1: {}
 
   oxfmt@0.43.0:
@@ -1474,6 +1636,19 @@ snapshots:
       '@oxlint/binding-win32-x64-msvc': 1.58.0
       oxlint-tsgolint: 0.20.0
 
+  parse5-htmlparser2-tree-adapter@7.1.0:
+    dependencies:
+      domhandler: 5.0.3
+      parse5: 7.3.0
+
+  parse5-parser-stream@7.1.2:
+    dependencies:
+      parse5: 7.3.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
+
   pathe@2.0.3: {}
 
   picocolors@1.1.1: {}
@@ -1516,6 +1691,8 @@ snapshots:
       - '@emnapi/core'
       - '@emnapi/runtime'
 
+  safer-buffer@2.1.2: {}
+
   siginfo@2.0.0: {}
 
   sirv@3.0.2:
@@ -1551,6 +1728,8 @@ snapshots:
   typescript@6.0.2: {}
 
   undici-types@7.19.2: {}
+
+  undici@7.25.0: {}
 
   vite-plus@0.1.16(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)):
     dependencies:
@@ -1637,6 +1816,12 @@ snapshots:
       '@types/node': 25.6.0
     transitivePeerDependencies:
       - msw
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
 
   why-is-node-running@2.3.0:
     dependencies:

--- a/scripts/check-supported-syntax-names.mjs
+++ b/scripts/check-supported-syntax-names.mjs
@@ -1,26 +1,6 @@
-import { readFile } from "node:fs/promises";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
+import { SUPPORTED_SYNTAX_COMPONENT_NAMES } from "../packages/core/src/supported-syntax.ts";
 
 const SPEC_URL = "https://www.w3.org/TR/css-properties-values-api-1/#supported-names";
-const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
-const SOURCE_FILE = path.join(
-  SCRIPT_DIR,
-  "../packages/core/src/supported-syntax.ts",
-);
-
-async function readLocalSupportedNames() {
-  const source = await readFile(SOURCE_FILE, "utf8");
-  const arrayMatch = source.match(
-    /SUPPORTED_SYNTAX_COMPONENT_NAMES\s*=\s*Object\.freeze\(\[(?<entries>[\s\S]*?)\]\s+as const\)/,
-  );
-
-  if (!arrayMatch?.groups?.entries) {
-    throw new Error("Could not read SUPPORTED_SYNTAX_COMPONENT_NAMES from supported-syntax.ts.");
-  }
-
-  return [...arrayMatch.groups.entries.matchAll(/"(<[a-z-]+>)"/gi)].map((match) => match[1]);
-}
 
 function extractSupportedNames(documentText) {
   const sectionStart = documentText.indexOf('id="supported-names"');
@@ -54,7 +34,7 @@ async function main() {
 
   const documentText = await response.text();
   const specNames = extractSupportedNames(documentText).sort();
-  const localNames = (await readLocalSupportedNames()).sort();
+  const localNames = [...SUPPORTED_SYNTAX_COMPONENT_NAMES].sort();
 
   const missingLocally = specNames.filter((name) => !localNames.includes(name));
   const onlyLocal = localNames.filter((name) => !specNames.includes(name));

--- a/scripts/check-supported-syntax-names.mjs
+++ b/scripts/check-supported-syntax-names.mjs
@@ -1,0 +1,80 @@
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const SPEC_URL = "https://www.w3.org/TR/css-properties-values-api-1/#supported-names";
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const SOURCE_FILE = path.join(
+  SCRIPT_DIR,
+  "../packages/core/src/supported-syntax.ts",
+);
+
+async function readLocalSupportedNames() {
+  const source = await readFile(SOURCE_FILE, "utf8");
+  const arrayMatch = source.match(
+    /SUPPORTED_SYNTAX_COMPONENT_NAMES\s*=\s*Object\.freeze\(\[(?<entries>[\s\S]*?)\]\s+as const\)/,
+  );
+
+  if (!arrayMatch?.groups?.entries) {
+    throw new Error("Could not read SUPPORTED_SYNTAX_COMPONENT_NAMES from supported-syntax.ts.");
+  }
+
+  return [...arrayMatch.groups.entries.matchAll(/"(<[a-z-]+>)"/gi)].map((match) => match[1]);
+}
+
+function extractSupportedNames(documentText) {
+  const sectionStart = documentText.indexOf('id="supported-names"');
+  const sectionEnd = documentText.indexOf('id="multipliers"', sectionStart);
+
+  if (sectionStart === -1 || sectionEnd === -1) {
+    throw new Error("Could not find the Supported Names section in the downloaded spec.");
+  }
+
+  const sectionText = documentText.slice(sectionStart, sectionEnd);
+  const names = [...sectionText.matchAll(/<dt[^>]*data-md[^>]*>"(&lt;[a-z-]+>)"/gi)].map((match) =>
+    match[1].replaceAll("&lt;", "<"),
+  );
+  return [...new Set(names)];
+}
+
+function formatDiff(kind, names) {
+  if (names.length === 0) {
+    return "";
+  }
+
+  return `${kind}:\n${names.map((name) => `- ${name}`).join("\n")}`;
+}
+
+async function main() {
+  const response = await fetch(SPEC_URL);
+
+  if (!response.ok) {
+    throw new Error(`Failed to download the supported-names section: ${response.status}`);
+  }
+
+  const documentText = await response.text();
+  const specNames = extractSupportedNames(documentText).sort();
+  const localNames = (await readLocalSupportedNames()).sort();
+
+  const missingLocally = specNames.filter((name) => !localNames.includes(name));
+  const onlyLocal = localNames.filter((name) => !specNames.includes(name));
+
+  if (missingLocally.length === 0 && onlyLocal.length === 0) {
+    process.stdout.write("Supported syntax names match the current published spec.\n");
+    return;
+  }
+
+  const parts = [
+    "Supported syntax names differ from the published spec. Review the diff before updating the frozen list.",
+    formatDiff("Present in spec but missing locally", missingLocally),
+    formatDiff("Present locally but not in spec", onlyLocal),
+  ].filter(Boolean);
+
+  process.stderr.write(`${parts.join("\n\n")}\n`);
+  process.exitCode = 1;
+}
+
+main().catch((error) => {
+  process.stderr.write(`${(error instanceof Error ? error.message : String(error))}\n`);
+  process.exit(1);
+});

--- a/scripts/check-supported-syntax-names.mjs
+++ b/scripts/check-supported-syntax-names.mjs
@@ -1,19 +1,35 @@
+import * as cheerio from "cheerio";
+
 import { SUPPORTED_SYNTAX_COMPONENT_NAMES } from "../packages/core/src/supported-syntax.ts";
 
 const SPEC_URL = "https://www.w3.org/TR/css-properties-values-api-1/#supported-names";
 
 function extractSupportedNames(documentText) {
-  const sectionStart = documentText.indexOf('id="supported-names"');
-  const sectionEnd = documentText.indexOf('id="multipliers"', sectionStart);
+  const $ = cheerio.load(documentText);
+  const sectionHeading = $("#supported-names");
 
-  if (sectionStart === -1 || sectionEnd === -1) {
+  if (sectionHeading.length === 0) {
     throw new Error("Could not find the Supported Names section in the downloaded spec.");
   }
 
-  const sectionText = documentText.slice(sectionStart, sectionEnd);
-  const names = [...sectionText.matchAll(/<dt[^>]*data-md[^>]*>"(&lt;[a-z-]+>)"/gi)].map((match) =>
-    match[1].replaceAll("&lt;", "<"),
-  );
+  const names = [];
+  let currentNode = sectionHeading.next();
+
+  while (currentNode.length > 0 && currentNode.attr("id") !== "multipliers") {
+    if (currentNode.is("dl")) {
+      currentNode.find('dt[data-md]').each((_, element) => {
+        const text = $(element).text().trim();
+        const quotedNameMatch = text.match(/^"(<[\w-]+>)"$/);
+
+        if (quotedNameMatch) {
+          names.push(quotedNameMatch[1]);
+        }
+      });
+    }
+
+    currentNode = currentNode.next();
+  }
+
   return [...new Set(names)];
 }
 


### PR DESCRIPTION
## Summary
Align `@property` registration validation with CSS Properties and Values API Level 1 so only valid registrations enter the registry.

## What changed
- require valid `syntax`, `inherits`, and non-universal `initial-value` descriptors for registrations
- validate that non-`*` `initial-value` values match the declared syntax and are computationally independent
- treat unknown descriptors as ignored rather than registration-invalidating
- enforce supported syntax component names from the spec instead of relying only on `css-tree`
- preserve last-valid-registration-wins behavior when later registrations are invalid
- add a supported-syntax verification script against the published spec
- expand the core test suite around registration validity, precedence, and spec maintenance checks

## Why
This project is a validator, so later value validation should be built on a registry that reflects spec-valid `@property` rules. The previous implementation accepted registrations the spec says should be ignored, which could lead to downstream false positives or misleading behavior.

## Validation
- `pnpm run typecheck`
- `pnpm run build`
- `pnpm test`
- `pnpm run check:supported-syntax-names`

## Follow-up
- Closes #21
- Related follow-ups: #25 and #26
