### PR TITLE
feat: Add local import traversal for registry assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install --global @schalkneethling/css-property-type-validator-cli
 Or run it without a global install:
 
 ```bash
-npx @schalkneethling/css-property-type-validator-cli example.css
+npx @schalkneethling/css-property-type-validator-cli fixtures/imports/main.css
 ```
 
 ### Core library
@@ -63,7 +63,7 @@ import { validateFiles } from "@schalkneethling/css-property-type-validator-core
 
 const result = validateFiles([
   {
-    path: "example.css",
+    path: "fixtures/imports/main.css",
     css: `
       @property --brand-color {
         syntax: "<color>";
@@ -87,6 +87,7 @@ console.log(result.diagnostics);
 css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
+css-property-type-validator "fixtures/imports/main.css"
 ```
 
 Human output is the default. The CLI exits with:
@@ -102,17 +103,17 @@ Human output is the default. The CLI exits with:
   "diagnostics": [
     {
       "code": "incompatible-var-usage",
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css",
+      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css",
       "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css",
+        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css",
         "start": {
-          "offset": 1356,
-          "line": 76,
+          "offset": 932,
+          "line": 38,
           "column": 16
         },
         "end": {
-          "offset": 1374,
-          "line": 76,
+          "offset": 950,
+          "line": 38,
           "column": 34
         }
       },
@@ -124,17 +125,17 @@ Human output is the default. The CLI exits with:
     },
     {
       "code": "incompatible-var-usage",
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css",
+      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css",
       "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css",
+        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css",
         "start": {
-          "offset": 1385,
-          "line": 77,
+          "offset": 961,
+          "line": 39,
           "column": 10
         },
         "end": {
-          "offset": 1400,
-          "line": 77,
+          "offset": 976,
+          "line": 39,
           "column": 25
         }
       },
@@ -147,11 +148,11 @@ Human output is the default. The CLI exits with:
   ],
   "registry": [
     {
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css",
-      "inherits": true,
-      "initialValue": "transparent",
+      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/nested.css",
+      "inherits": false,
+      "initialValue": "12px",
       "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css",
+        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/nested.css",
         "start": {
           "offset": 0,
           "line": 1,
@@ -163,23 +164,43 @@ Human output is the default. The CLI exits with:
           "column": 2
         }
       },
+      "name": "--radius-lg",
+      "syntax": "<length>"
+    },
+    {
+      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/tokens.css",
+      "inherits": true,
+      "initialValue": "transparent",
+      "loc": {
+        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/tokens.css",
+        "start": {
+          "offset": 25,
+          "line": 3,
+          "column": 1
+        },
+        "end": {
+          "offset": 121,
+          "line": 7,
+          "column": 2
+        }
+      },
       "name": "--brand-color",
       "syntax": "<color>"
     },
     {
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css",
+      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/tokens.css",
       "inherits": false,
-      "initialValue": "1rem",
+      "initialValue": "16px",
       "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css",
+        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/tokens.css",
         "start": {
-          "offset": 98,
-          "line": 7,
+          "offset": 123,
+          "line": 9,
           "column": 1
         },
         "end": {
-          "offset": 186,
-          "line": 11,
+          "offset": 211,
+          "line": 13,
           "column": 2
         }
       },
@@ -187,12 +208,12 @@ Human output is the default. The CLI exits with:
       "syntax": "<length>"
     }
   ],
-  "skippedDeclarations": 1,
-  "validatedDeclarations": 15
+  "skippedDeclarations": 0,
+  "validatedDeclarations": 30
 }
 ```
 
-This example is truncated for readability. A full run against [example.css](/Users/schalkneethling/dev/opensource/css-property-type-validator/example.css) includes additional diagnostics and all registered properties in the combined registry.
+This example is truncated for readability. A full run against [fixtures/imports/main.css](/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css) also includes invalid `@property` registrations from imported registry files, authored custom property assignment diagnostics, and more specific multi-`var()` messages when the validator can narrow the likely culprit.
 
 ## Current validation model
 
@@ -206,10 +227,12 @@ css-property-type-validator "src/components/**/*.css" --registry "src/tokens/**/
 
 Registry-only files contribute `@property` registrations and any registration/parse diagnostics, but their own normal declarations are not validated unless you also pass them as main inputs.
 
+When a resolver is available, the validator also follows local unconditioned `@import` rules while assembling the registry. That includes relative imports and root-relative imports in the CLI. Remote imports and conditioned imports remain intentionally out of scope for now.
+
 For this first cut, compatibility checks are intentionally conservative:
 
 - whitespace-toggle and similarly ambiguous custom property assignment patterns are skipped for now
-- automatic `@import` resolution is not implemented yet
+- conditioned and remote `@import` traversal are not implemented yet
 - config-file based registry discovery is not implemented yet
 
 That keeps false positives down while the standalone core takes shape.

--- a/fixtures/imports/ignored/conditional.css
+++ b/fixtures/imports/ignored/conditional.css
@@ -1,0 +1,5 @@
+@property --conditional-only {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: hotpink;
+}

--- a/fixtures/imports/main.css
+++ b/fixtures/imports/main.css
@@ -1,56 +1,7 @@
-@property --brand-color {
-  syntax: "<color>";
-  inherits: true;
-  initial-value: transparent;
-}
-
-@property --space-md {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 1rem;
-}
-
-@property --radius-lg {
-  syntax: "<length>";
-  inherits: false;
-  initial-value: 12px;
-}
-
-@property --fast-transition {
-  syntax: "<time>";
-  inherits: false;
-  initial-value: 150ms;
-}
-
-@property --overlay-alpha {
-  syntax: "<number>";
-  inherits: false;
-  initial-value: 0.6;
-}
-
-@property --card-shadow {
-  syntax: "<shadow>";
-  inherits: false;
-  initial-value: 0 2px 8px rgb(0 0 0 / 0.12);
-}
-
-@property --hero-image {
-  syntax: "<image>";
-  inherits: false;
-  initial-value: url("hero-default.png");
-}
-
-@property --accent-ratio {
-  syntax: "<ratio>";
-  inherits: false;
-  initial-value: 16/9;
-}
-
-@property --heading-font {
-  syntax: "<font-family>";
-  inherits: true;
-  initial-value: serif;
-}
+@import "./registry/tokens.css";
+@import "/fixtures/imports/root/root-tokens.css";
+@import "./ignored/conditional.css" screen;
+@import "https://example.com/remote.css";
 
 /*
   Valid usages developers would expect to keep passing.
@@ -62,13 +13,10 @@
   border-start-start-radius: var(--radius-lg);
   border: var(--radius-lg) solid var(--brand-color);
   transition-duration: var(--fast-transition);
-  box-shadow: var(--card-shadow);
-  font-family: var(--heading-font);
 }
 
 .hero {
-  background-image: var(--hero-image);
-  aspect-ratio: var(--accent-ratio);
+  background-image: var(--hero-url);
   color: var(--brand-color);
   padding-inline: var(--space-md);
 }
@@ -80,6 +28,7 @@
   --brand-color: rebeccapurple;
   --space-md: 1.5rem;
   --radius-lg: var(--space-md);
+  --hero-url: url("https://example.com/hero-theme.png");
 }
 
 /*
@@ -93,8 +42,6 @@
   border: var(--brand-color) solid var(--brand-color);
   transition-duration: var(--overlay-alpha);
   background-image: var(--brand-color);
-  box-shadow: var(--space-md);
-  aspect-ratio: var(--heading-font);
 }
 
 /*
@@ -103,7 +50,7 @@
 .theme-broken {
   --brand-color: 10px;
   --space-md: tomato;
-  --hero-image: var(--brand-color);
+  --hero-url: red;
 }
 
 /*
@@ -129,4 +76,11 @@
   margin-inline: var(--brand-color) var(--radius-lg);
   border: var(--brand-color) solid var(--brand-color);
   color: var(--space-md);
+}
+
+/*
+  Some multi-var() declarations remain only diagnosable at the declaration level.
+*/
+.layout--broken {
+  margin: var(--brand-color) var(--brand-color);
 }

--- a/fixtures/imports/registry/nested.css
+++ b/fixtures/imports/registry/nested.css
@@ -1,0 +1,17 @@
+@property --radius-lg {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 12px;
+}
+
+@property --fast-transition {
+  syntax: "<time>";
+  inherits: false;
+  initial-value: 150ms;
+}
+
+@property --overlay-alpha {
+  syntax: "<number>";
+  inherits: false;
+  initial-value: 0.6;
+}

--- a/fixtures/imports/registry/tokens.css
+++ b/fixtures/imports/registry/tokens.css
@@ -1,0 +1,20 @@
+@import "./nested.css";
+
+@property --brand-color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: transparent;
+}
+
+@property --space-md {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 16px;
+}
+
+/*
+  Imported registry sources should not become validation targets automatically.
+*/
+.tokens-should-not-validate {
+  inline-size: var(--brand-color);
+}

--- a/fixtures/imports/root/root-tokens.css
+++ b/fixtures/imports/root/root-tokens.css
@@ -1,0 +1,43 @@
+@property --hero-url {
+  syntax: "<url>";
+  inherits: false;
+  initial-value: url("https://example.com/hero-default.png");
+}
+
+/*
+  Invalid registrations should be reported and omitted from the collected registry.
+*/
+@property --broken-syntax {
+  syntax: "<color";
+  inherits: true;
+  initial-value: transparent;
+}
+
+@property --missing-inherits {
+  syntax: "<length>";
+  initial-value: 0px;
+}
+
+@property --bad-initial-color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: 10px;
+}
+
+@property --relative-space {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 3em;
+}
+
+@property --relative-image {
+  syntax: "<image>";
+  inherits: false;
+  initial-value: url("hero-local.png");
+}
+
+@property --var-based-space {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: var(--space-md);
+}

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "typecheck": "tsc -b tsconfig.json",
     "check:supported-syntax-names": "node scripts/check-supported-syntax-names.mjs",
     "clean": "node scripts/clean.mjs",
-    "example": "pnpm run build && node packages/cli/dist/cli.js example.css"
+    "example": "pnpm run build && node packages/cli/dist/cli.js fixtures/imports/main.css"
   },
   "devDependencies": {
     "@types/node": "^25.6.0",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,6 +22,7 @@ npx @schalkneethling/css-property-type-validator-cli "src/**/*.css"
 css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
+css-property-type-validator "fixtures/imports/main.css"
 ```
 
 Use `--registry` multiple times to include shared `@property` definitions without validating the rest of those files:
@@ -32,7 +33,7 @@ css-property-type-validator "src/**/*.css" \
   --registry "src/brand/**/*.css"
 ```
 
-Registry-only files still report parse errors and invalid `@property` registrations. Automatic `@import` traversal is not supported yet.
+Registry-only files still report parse errors and invalid `@property` registrations. The CLI also follows local unconditioned `@import` rules automatically while assembling the registry, including relative and root-relative imports. Remote and conditioned imports are still out of scope for now.
 
 ## Exit codes
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
+import { readFileSync } from "node:fs";
 import { glob, readFile } from "node:fs/promises";
+import path from "node:path";
 import process from "node:process";
 
 import { Command } from "commander";
@@ -8,7 +10,10 @@ import { Command } from "commander";
 import { validateFiles } from "@schalkneethling/css-property-type-validator-core";
 import { formatValidationResult } from "./formatter.js";
 
-import type { ValidationInput } from "@schalkneethling/css-property-type-validator-core";
+import type {
+  ResolveImport,
+  ValidationInput,
+} from "@schalkneethling/css-property-type-validator-core";
 
 type OutputFormat = "human" | "json";
 
@@ -32,6 +37,27 @@ async function loadInputs(patterns: string[]): Promise<ValidationInput[]> {
   );
 
   return inputs.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+function createImportResolver(cwd: string): ResolveImport {
+  return (specifier: string, fromPath: string) => {
+    const resolvedPath = specifier.startsWith("/")
+      ? path.join(cwd, specifier.slice(1))
+      : path.resolve(path.dirname(fromPath), specifier);
+
+    if (!resolvedPath.endsWith(".css")) {
+      return null;
+    }
+
+    try {
+      return {
+        path: resolvedPath,
+        css: readFileSync(resolvedPath, "utf8"),
+      };
+    } catch {
+      return null;
+    }
+  };
 }
 
 async function loadRegistryInputs(
@@ -71,7 +97,10 @@ async function main(): Promise<void> {
       }
 
       const registryInputs = await loadRegistryInputs(options.registry, inputs);
-      const result = validateFiles(inputs, { registryInputs });
+      const result = validateFiles(inputs, {
+        registryInputs,
+        resolveImport: createImportResolver(process.cwd()),
+      });
       const output = formatValidationResult(result, format);
 
       process.stdout.write(`${output}\n`);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -18,17 +18,23 @@ import { validateFiles } from "@schalkneethling/css-property-type-validator-core
 const result = validateFiles(
   [
     {
-      path: "example.css",
+      path: "fixtures/imports/main.css",
       css: `
+        @import "./tokens.css";
+
         .card {
-          inline-size: var(--brand-color);
+          color: var(--brand-color);
         }
       `,
     },
   ],
   {
-    registryInputs: [
-      {
+    resolveImport: (specifier, fromPath) => {
+      if (specifier !== "./tokens.css" || fromPath !== "fixtures/imports/main.css") {
+        return null;
+      }
+
+      return {
         path: "tokens.css",
         css: `
           @property --brand-color {
@@ -37,8 +43,8 @@ const result = validateFiles(
             initial-value: transparent;
           }
         `,
-      },
-    ],
+      };
+    },
   },
 );
 
@@ -50,9 +56,11 @@ console.log(result.diagnostics);
 - Validates `@property` syntax descriptors
 - Builds a registry across provided input files
 - Can extend that registry with optional `registryInputs`
+- Can follow local unconditioned `@import` rules when `resolveImport` is provided
 - Validates single-`var()` declaration usages
 - Validates authored values assigned to registered custom properties
 - Skips whitespace-toggle and similarly ambiguous custom property assignment patterns for now
+- Skips conditioned and remote `@import` traversal for now
 - Ignores unregistered custom properties
 
 Repository: [schalkneethling/css-property-type-validator](https://github.com/schalkneethling/css-property-type-validator)

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -3,6 +3,7 @@ export type { ValidateFilesOptions } from "./validate.js";
 
 export type {
   RegisteredProperty,
+  ResolveImport,
   SourceLocation,
   SourcePosition,
   ValidationDiagnostic,

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -2,7 +2,72 @@ import * as cssTree from "css-tree";
 
 import { getFirstUnsupportedSyntaxComponentName } from "./supported-syntax.js";
 
-import type { RegisteredProperty, ValidationDiagnostic, ValidationInput } from "./types.js";
+import type {
+  RegisteredProperty,
+  ResolveImport,
+  ValidationDiagnostic,
+  ValidationInput,
+} from "./types.js";
+
+interface CssNodeWithLoc {
+  loc?: unknown;
+}
+
+interface CssValueNode extends CssNodeWithLoc {
+  children?: ArrayLike<unknown>;
+}
+
+interface CssDeclarationNode extends CssNodeWithLoc {
+  property?: string;
+  value?: CssValueNode;
+}
+
+interface CssPreludeNode extends CssNodeWithLoc {
+  children?: ArrayLike<unknown>;
+}
+
+interface CssBlockNode extends CssNodeWithLoc {
+  children?: ArrayLike<unknown>;
+}
+
+interface CssAtruleNode extends CssNodeWithLoc {
+  name?: string;
+  type?: string;
+  prelude?: CssPreludeNode;
+  block?: CssBlockNode | null;
+}
+
+interface CssStringNode {
+  type: "String";
+  value?: string;
+}
+
+interface CssUrlNode {
+  type: "Url";
+  value?: string;
+}
+
+interface CssPropertyNameNode {
+  name?: string;
+}
+
+interface CssStylesheet {
+  children?: ArrayLike<unknown>;
+}
+
+interface CssLocation {
+  end: RegisteredProperty["loc"] extends infer T
+    ? T extends { end: infer End }
+      ? End
+      : never
+    : never;
+  source?: string;
+  start: RegisteredProperty["loc"] extends infer T
+    ? T extends { start: infer Start }
+      ? Start
+      : never
+    : never;
+}
 
 const COMPUTATION_INDEPENDENT_DIMENSION_UNITS = Object.freeze([
   "cm",
@@ -38,27 +103,33 @@ function toBoolean(value: string | undefined): boolean | undefined {
   return undefined;
 }
 
-function toLocation(loc: any): RegisteredProperty["loc"] {
-  return loc
-    ? {
-        source: loc.source,
-        start: { ...loc.start },
-        end: { ...loc.end },
-      }
-    : null;
+function toLocation(loc: unknown): RegisteredProperty["loc"] {
+  if (!loc) {
+    return null;
+  }
+
+  const typedLoc = loc as CssLocation;
+
+  return {
+    source: typedLoc.source,
+    start: { ...typedLoc.start },
+    end: { ...typedLoc.end },
+  };
 }
 
-function descriptorMap(block: any): Map<string, any> {
-  const descriptors = new Map<string, any>();
+function descriptorMap(block: CssBlockNode | null | undefined): Map<string, CssDeclarationNode> {
+  const descriptors = new Map<string, CssDeclarationNode>();
 
-  for (const declaration of block?.children ?? []) {
-    descriptors.set(declaration.property, declaration);
+  for (const declaration of Array.from(block?.children ?? []) as CssDeclarationNode[]) {
+    if (declaration.property) {
+      descriptors.set(declaration.property, declaration);
+    }
   }
 
   return descriptors;
 }
 
-function parseValue(value: string): any | null {
+function parseValue(value: string): unknown | null {
   try {
     return cssTree.parse(value, { context: "value" });
   } catch {
@@ -75,11 +146,11 @@ function isAbsoluteUrl(url: string): boolean {
   }
 }
 
-function getComputationalIndependenceFailureReason(value: any): string | null {
+function getComputationalIndependenceFailureReason(value: unknown): string | null {
   let failure: string | null = null;
 
   cssTree.walk(value, {
-    enter(node: any) {
+    enter(node: { name?: string; type?: string; unit?: string; value?: string }) {
       if (failure) {
         return;
       }
@@ -153,8 +224,11 @@ function validateInitialValueAgainstSyntax(
   return null;
 }
 
-function getStringDescriptor(declaration: any): string | undefined {
-  const firstNode = declaration?.value?.children?.first ?? declaration?.value?.children?.[0];
+function getStringDescriptor(declaration: CssDeclarationNode | undefined): string | undefined {
+  const valueChildren = declaration?.value?.children;
+  const firstNode = (valueChildren
+    ? (Array.from(valueChildren)[0] as CssStringNode | undefined)
+    : undefined);
 
   if (firstNode?.type === "String") {
     return firstNode.value;
@@ -163,7 +237,7 @@ function getStringDescriptor(declaration: any): string | undefined {
   return undefined;
 }
 
-function getRawDescriptor(declaration: any): string | undefined {
+function getRawDescriptor(declaration: CssDeclarationNode | undefined): string | undefined {
   if (!declaration?.value) {
     return undefined;
   }
@@ -171,21 +245,217 @@ function getRawDescriptor(declaration: any): string | undefined {
   return cssTree.generate(declaration.value).trim();
 }
 
-export function collectRegistry(inputs: ValidationInput[]): {
+function getImportSpecifier(importRule: CssAtruleNode): string | null {
+  const preludeChildren = Array.from(importRule.prelude?.children ?? []) as Array<
+    CssStringNode | CssUrlNode
+  >;
+
+  if (preludeChildren.length !== 1) {
+    return null;
+  }
+
+  const firstPreludeNode = preludeChildren[0];
+
+  if (firstPreludeNode?.type === "String" || firstPreludeNode?.type === "Url") {
+    return String(firstPreludeNode.value ?? "");
+  }
+
+  return null;
+}
+
+function isAbsoluteImportUrl(importSpecifier: string): boolean {
+  try {
+    new URL(importSpecifier);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function processPropertyRule(
+  input: ValidationInput,
+  node: CssAtruleNode,
+  diagnostics: ValidationDiagnostic[],
+  registry: Map<string, RegisteredProperty>,
+): void {
+  const propertyName = (
+    Array.from(node.prelude?.children ?? []) as CssPropertyNameNode[]
+  )[0]?.name;
+
+  if (!propertyName) {
+    diagnostics.push({
+      code: "invalid-property-registration",
+      filePath: input.path,
+      loc: toLocation(node.loc),
+      message: "Found an @property rule without a custom property name.",
+    });
+    return;
+  }
+
+  const descriptors = descriptorMap(node.block);
+  const syntaxDeclaration = descriptors.get("syntax");
+  const syntax = getStringDescriptor(syntaxDeclaration);
+  const inheritsDescriptor = descriptors.get("inherits");
+  const inheritsRaw = getRawDescriptor(inheritsDescriptor);
+  const inherits = toBoolean(inheritsRaw);
+  const initialValue = getRawDescriptor(descriptors.get("initial-value"));
+
+  if (!syntax) {
+    diagnostics.push({
+      code: "invalid-property-registration",
+      filePath: input.path,
+      loc: toLocation(node.loc),
+      message: `@property ${propertyName} is missing a valid string-valued syntax descriptor.`,
+      propertyName,
+    });
+    return;
+  }
+
+  let syntaxAst: unknown;
+
+  try {
+    if (syntax !== "*") {
+      syntaxAst = cssTree.definitionSyntax.parse(syntax);
+    }
+  } catch (error) {
+    diagnostics.push({
+      code: "invalid-property-registration",
+      filePath: input.path,
+      loc: toLocation(node.loc),
+      message: `@property ${propertyName} has an invalid syntax descriptor "${syntax}": ${(error as Error).message}`,
+      propertyName,
+      registeredSyntax: syntax,
+    });
+    return;
+  }
+
+  if (syntax !== "*") {
+    // CSS Properties and Values API Level 1 §5.4.4 only accepts supported syntax
+    // component names from §5.1:
+    // https://www.w3.org/TR/css-properties-values-api-1/#supported-names
+    const unsupportedName = getFirstUnsupportedSyntaxComponentName(syntaxAst);
+
+    if (unsupportedName) {
+      diagnostics.push({
+        code: "invalid-property-registration",
+        filePath: input.path,
+        loc: toLocation(node.loc),
+        message: `@property ${propertyName} uses the unsupported syntax component name "${unsupportedName}".`,
+        propertyName,
+        registeredSyntax: syntax,
+      });
+      return;
+    }
+  }
+
+  // Unknown descriptors are intentionally ignored and do not invalidate the
+  // @property rule. We only validate the known descriptors defined by the spec.
+  // CSS Properties and Values API Level 1 §3:
+  // https://www.w3.org/TR/css-properties-values-api-1/#at-property-rule
+  if (!inheritsDescriptor) {
+    diagnostics.push({
+      code: "invalid-property-registration",
+      filePath: input.path,
+      loc: toLocation(node.loc),
+      message: `@property ${propertyName} is missing the required inherits descriptor.`,
+      propertyName,
+      registeredSyntax: syntax,
+    });
+    return;
+  }
+
+  if (inherits === undefined) {
+    diagnostics.push({
+      code: "invalid-property-registration",
+      filePath: input.path,
+      loc: toLocation(node.loc),
+      message: `@property ${propertyName} must set inherits to true or false.`,
+      propertyName,
+      registeredSyntax: syntax,
+    });
+    return;
+  }
+
+  // CSS Properties and Values API Level 1 §3.3 only allows omitted initial-value
+  // when the syntax is the universal syntax definition:
+  // https://www.w3.org/TR/css-properties-values-api-1/#initial-value-descriptor
+  if (syntax !== "*" && !initialValue) {
+    diagnostics.push({
+      code: "invalid-property-registration",
+      filePath: input.path,
+      loc: toLocation(node.loc),
+      message: `@property ${propertyName} is missing the required initial-value descriptor for non-universal syntax "${syntax}".`,
+      propertyName,
+      registeredSyntax: syntax,
+    });
+    return;
+  }
+
+  if (syntax !== "*" && initialValue) {
+    const initialValueFailure = validateInitialValueAgainstSyntax(
+      propertyName,
+      syntax,
+      initialValue,
+    );
+
+    if (initialValueFailure) {
+      diagnostics.push({
+        code: "invalid-property-registration",
+        filePath: input.path,
+        loc: toLocation(node.loc),
+        message: initialValueFailure,
+        propertyName,
+        registeredSyntax: syntax,
+      });
+      return;
+    }
+  }
+
+  // CSS Cascading and Inheritance Level 5 §2 says imported stylesheets behave as
+  // if their contents were written at the point of the @import:
+  // https://www.w3.org/TR/css-cascade-5/#at-import
+  // CSS Properties and Values API Level 1 §2.1 says the last valid registration in
+  // document order wins. Invalid later rules must not displace an earlier valid one:
+  // https://www.w3.org/TR/css-properties-values-api-1/#determining-the-registration
+  registry.set(propertyName, {
+    filePath: input.path,
+    inherits,
+    initialValue,
+    loc: toLocation(node.loc),
+    name: propertyName,
+    syntax,
+  });
+}
+
+export function collectRegistry(
+  inputs: ValidationInput[],
+  options: { resolveImport?: ResolveImport } = {},
+): {
   diagnostics: ValidationDiagnostic[];
   registry: RegisteredProperty[];
 } {
   const diagnostics: ValidationDiagnostic[] = [];
   const registry = new Map<string, RegisteredProperty>();
+  const expandedPaths = new Set<string>();
+  const activePaths = new Set<string>();
 
-  for (const input of inputs) {
-    let ast: any;
+  function processInput(input: ValidationInput): void {
+    if (activePaths.has(input.path) || expandedPaths.has(input.path)) {
+      return;
+    }
+
+    // CSS files can import each other cyclically. Since each stylesheet is parsed
+    // independently, the parser itself is fine; this guard prevents our traversal
+    // from recursing forever while expanding the import graph for registry assembly.
+    activePaths.add(input.path);
+
+    let ast: CssStylesheet;
 
     try {
       ast = cssTree.parse(input.css, {
         filename: input.path,
         positions: true,
-      });
+      }) as CssStylesheet;
     } catch (error) {
       diagnostics.push({
         code: "unparseable-stylesheet",
@@ -193,161 +463,51 @@ export function collectRegistry(inputs: ValidationInput[]): {
         loc: null,
         message: `Could not parse stylesheet: ${(error as Error).message}`,
       });
-      continue;
+      activePaths.delete(input.path);
+      expandedPaths.add(input.path);
+      return;
     }
 
-    cssTree.walk(ast, {
-      visit: "Atrule",
-      enter(node: any) {
-        if (node.name !== "property") {
-          return;
+    for (const node of Array.from(ast.children ?? []) as CssAtruleNode[]) {
+      if (node.type !== "Atrule") {
+        continue;
+      }
+
+      if (node.name === "import") {
+        const importSpecifier = getImportSpecifier(node);
+
+        if (!importSpecifier || isAbsoluteImportUrl(importSpecifier) || !options.resolveImport) {
+          continue;
         }
 
-        const propertyName =
-          node.prelude?.children?.first?.name ?? node.prelude?.children?.[0]?.name;
+        const resolvedImport = options.resolveImport(importSpecifier, input.path);
 
-        if (!propertyName) {
+        if (!resolvedImport) {
           diagnostics.push({
-            code: "invalid-property-registration",
+            code: "unresolved-import",
             filePath: input.path,
             loc: toLocation(node.loc),
-            message: "Found an @property rule without a custom property name.",
+            message: `Could not resolve imported stylesheet "${importSpecifier}" from ${input.path}.`,
+            snippet: cssTree.generate(node),
           });
-          return;
+          continue;
         }
 
-        const descriptors = descriptorMap(node.block);
-        const syntaxDeclaration = descriptors.get("syntax");
-        const syntax = getStringDescriptor(syntaxDeclaration);
-        const inheritsDescriptor = descriptors.get("inherits");
-        const inheritsRaw = getRawDescriptor(inheritsDescriptor);
-        const inherits = toBoolean(inheritsRaw);
-        const initialValue = getRawDescriptor(descriptors.get("initial-value"));
+        processInput(resolvedImport);
+        continue;
+      }
 
-        if (!syntax) {
-          diagnostics.push({
-            code: "invalid-property-registration",
-            filePath: input.path,
-            loc: toLocation(node.loc),
-            message: `@property ${propertyName} is missing a valid string-valued syntax descriptor.`,
-            propertyName,
-          });
-          return;
-        }
+      if (node.name === "property") {
+        processPropertyRule(input, node, diagnostics, registry);
+      }
+    }
 
-        let syntaxAst: any;
+    activePaths.delete(input.path);
+    expandedPaths.add(input.path);
+  }
 
-        try {
-          if (syntax !== "*") {
-            syntaxAst = cssTree.definitionSyntax.parse(syntax);
-          }
-        } catch (error) {
-          diagnostics.push({
-            code: "invalid-property-registration",
-            filePath: input.path,
-            loc: toLocation(node.loc),
-            message: `@property ${propertyName} has an invalid syntax descriptor "${syntax}": ${(error as Error).message}`,
-            propertyName,
-            registeredSyntax: syntax,
-          });
-          return;
-        }
-
-        if (syntax !== "*") {
-          // CSS Properties and Values API Level 1 §5.4.4 only accepts supported syntax
-          // component names from §5.1:
-          // https://www.w3.org/TR/css-properties-values-api-1/#supported-names
-          const unsupportedName = getFirstUnsupportedSyntaxComponentName(syntaxAst);
-
-          if (unsupportedName) {
-            diagnostics.push({
-              code: "invalid-property-registration",
-              filePath: input.path,
-              loc: toLocation(node.loc),
-              message: `@property ${propertyName} uses the unsupported syntax component name "${unsupportedName}".`,
-              propertyName,
-              registeredSyntax: syntax,
-            });
-            return;
-          }
-        }
-
-        // Unknown descriptors are intentionally ignored and do not invalidate the
-        // @property rule. We only validate the known descriptors defined by the spec.
-        // CSS Properties and Values API Level 1 §3:
-        // https://www.w3.org/TR/css-properties-values-api-1/#at-property-rule
-        if (!inheritsDescriptor) {
-          diagnostics.push({
-            code: "invalid-property-registration",
-            filePath: input.path,
-            loc: toLocation(node.loc),
-            message: `@property ${propertyName} is missing the required inherits descriptor.`,
-            propertyName,
-            registeredSyntax: syntax,
-          });
-          return;
-        }
-
-        if (inherits === undefined) {
-          diagnostics.push({
-            code: "invalid-property-registration",
-            filePath: input.path,
-            loc: toLocation(node.loc),
-            message: `@property ${propertyName} must set inherits to true or false.`,
-            propertyName,
-            registeredSyntax: syntax,
-          });
-          return;
-        }
-
-        // CSS Properties and Values API Level 1 §3.3 only allows omitted initial-value
-        // when the syntax is the universal syntax definition:
-        // https://www.w3.org/TR/css-properties-values-api-1/#initial-value-descriptor
-        if (syntax !== "*" && !initialValue) {
-          diagnostics.push({
-            code: "invalid-property-registration",
-            filePath: input.path,
-            loc: toLocation(node.loc),
-            message: `@property ${propertyName} is missing the required initial-value descriptor for non-universal syntax "${syntax}".`,
-            propertyName,
-            registeredSyntax: syntax,
-          });
-          return;
-        }
-
-        if (syntax !== "*" && initialValue) {
-          const initialValueFailure = validateInitialValueAgainstSyntax(
-            propertyName,
-            syntax,
-            initialValue,
-          );
-
-          if (initialValueFailure) {
-            diagnostics.push({
-              code: "invalid-property-registration",
-              filePath: input.path,
-              loc: toLocation(node.loc),
-              message: initialValueFailure,
-              propertyName,
-              registeredSyntax: syntax,
-            });
-            return;
-          }
-        }
-
-        // CSS Properties and Values API Level 1 §2.1 says the last valid registration in
-        // document order wins. Invalid later rules must not displace an earlier valid one:
-        // https://www.w3.org/TR/css-properties-values-api-1/#determining-registration
-        registry.set(propertyName, {
-          filePath: input.path,
-          inherits,
-          initialValue,
-          loc: toLocation(node.loc),
-          name: propertyName,
-          syntax,
-        });
-      },
-    });
+  for (const input of inputs) {
+    processInput(input);
   }
 
   return {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,6 +15,11 @@ export interface ValidationInput {
   css: string;
 }
 
+export type ResolveImport = (
+  specifier: string,
+  fromPath: string,
+) => ValidationInput | null;
+
 export interface RegisteredProperty {
   filePath: string;
   inherits?: boolean;
@@ -28,6 +33,7 @@ export type DiagnosticCode =
   | "invalid-property-registration"
   | "incompatible-custom-property-assignment"
   | "incompatible-var-usage"
+  | "unresolved-import"
   | "unparseable-stylesheet";
 
 export interface ValidationDiagnostic {

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -5,6 +5,7 @@ import { collectRegistry } from "./registry.js";
 
 import type {
   RegisteredProperty,
+  ResolveImport,
   ValidationDiagnostic,
   ValidationInput,
   ValidationResult,
@@ -12,6 +13,7 @@ import type {
 
 export interface ValidateFilesOptions {
   registryInputs?: ValidationInput[];
+  resolveImport?: ResolveImport;
 }
 
 function toLocation(loc: any): ValidationDiagnostic["loc"] {
@@ -77,23 +79,76 @@ function matchRegisteredSyntax(registration: RegisteredProperty, value: any): bo
   return Boolean(match?.matched);
 }
 
-function valueMatchesSamples(
-  value: any,
-  substitutions: Array<{ sample: string; varNode: any }>,
+function collectVarOccurrences(
+  valueSource: string,
+  varNodes: any[],
+): Array<{ end: number; start: number; varNode: any }> | null {
+  const occurrences = [];
+  let searchStart = 0;
+
+  for (const varNode of varNodes) {
+    const replacementTarget = cssTree.generate(varNode);
+    const start = valueSource.indexOf(replacementTarget, searchStart);
+
+    if (start === -1) {
+      return null;
+    }
+
+    const end = start + replacementTarget.length;
+
+    occurrences.push({ start, end, varNode });
+    searchStart = end;
+  }
+
+  return occurrences;
+}
+
+function renderValueWithReplacements(
+  valueSource: string,
+  occurrences: Array<{ end: number; start: number; varNode: any }>,
+  replacements: Array<string | null>,
+): string {
+  let rendered = "";
+  let cursor = 0;
+
+  for (const [index, occurrence] of occurrences.entries()) {
+    rendered += valueSource.slice(cursor, occurrence.start);
+    rendered += replacements[index] ?? "";
+    cursor = occurrence.end;
+  }
+
+  rendered += valueSource.slice(cursor);
+
+  return rendered.trim();
+}
+
+function valueMatchesRenderedSource(
+  renderedSource: string,
   matcher: (candidateValue: any) => boolean,
 ): boolean {
-  const valueSource = cssTree.generate(value);
-  const replacedSource = substitutions.reduce((source, substitution) => {
-    const replacementTarget = cssTree.generate(substitution.varNode);
-    return source.replace(replacementTarget, substitution.sample);
-  }, valueSource);
-  const replacedAst = parseValue(replacedSource);
+  const replacedAst = parseValue(renderedSource);
 
   if (!replacedAst) {
     return false;
   }
 
   return matcher(replacedAst);
+}
+
+function valueMatchesSamples(
+  valueSource: string,
+  occurrences: Array<{ end: number; start: number; varNode: any }>,
+  substitutions: Array<{ sample: string; varNode: any }>,
+  matcher: (candidateValue: any) => boolean,
+): boolean {
+  const replacementMap = new Map(substitutions.map((substitution) => [substitution.varNode, substitution.sample]));
+  const renderedSource = renderValueWithReplacements(
+    valueSource,
+    occurrences,
+    occurrences.map((occurrence) => replacementMap.get(occurrence.varNode) ?? null),
+  );
+
+  return valueMatchesRenderedSource(renderedSource, matcher);
 }
 
 function toVarDiagnostic(
@@ -132,6 +187,27 @@ function toVarDiagnostic(
   };
 }
 
+function toPossibleVarDiagnostic(
+  filePath: string,
+  declaration: any,
+  registrations: RegisteredProperty[],
+): ValidationDiagnostic {
+  const uniqueNames = [...new Set(registrations.map((registration) => registration.name))];
+  const message =
+    uniqueNames.length === 1
+      ? `One or more var() usages of registered property ${uniqueNames[0]} may be incompatible with ${declaration.property} at this declaration value.`
+      : `Registered properties ${uniqueNames.join(", ")} may be incompatible with ${declaration.property} at this declaration value.`;
+
+  return {
+    code: "incompatible-var-usage",
+    filePath,
+    loc: toLocation(declaration.value.loc),
+    message,
+    expectedProperty: declaration.property,
+    snippet: cssTree.generate(declaration),
+  };
+}
+
 function toAssignmentDiagnostic(
   filePath: string,
   declaration: any,
@@ -149,23 +225,118 @@ function toAssignmentDiagnostic(
 }
 
 function isCompatibleWithSubstitutions(
-  value: any,
+  valueSource: string,
+  occurrences: Array<{ end: number; start: number; varNode: any }>,
   substitutionOptions: Array<{ samples: string[]; varNode: any }>,
   matcher: (candidateValue: any) => boolean,
   index = 0,
   activeSubstitutions: Array<{ sample: string; varNode: any }> = [],
 ): boolean {
   if (index === substitutionOptions.length) {
-    return valueMatchesSamples(value, activeSubstitutions, matcher);
+    return valueMatchesSamples(valueSource, occurrences, activeSubstitutions, matcher);
   }
 
   const option = substitutionOptions[index];
 
   return option.samples.some((sample) =>
-    isCompatibleWithSubstitutions(value, substitutionOptions, matcher, index + 1, [
+    isCompatibleWithSubstitutions(valueSource, occurrences, substitutionOptions, matcher, index + 1, [
       ...activeSubstitutions,
       { sample, varNode: option.varNode },
     ]),
+  );
+}
+
+function canDeclarationMatchWithoutOccurrence(
+  valueSource: string,
+  occurrences: Array<{ end: number; start: number; varNode: any }>,
+  substitutionOptions: Array<{ index: number; samples: string[]; varNode: any }>,
+  matcher: (candidateValue: any) => boolean,
+  removedIndex: number,
+  optionIndex = 0,
+  replacements: Array<string | null> = Array.from({ length: occurrences.length }, () => null),
+): boolean {
+  if (optionIndex === substitutionOptions.length) {
+    const renderedSource = renderValueWithReplacements(valueSource, occurrences, replacements);
+    return valueMatchesRenderedSource(renderedSource, matcher);
+  }
+
+  const option = substitutionOptions[optionIndex];
+
+  if (option.index === removedIndex) {
+    return canDeclarationMatchWithoutOccurrence(
+      valueSource,
+      occurrences,
+      substitutionOptions,
+      matcher,
+      removedIndex,
+      optionIndex + 1,
+      replacements,
+    );
+  }
+
+  return option.samples.some((sample) => {
+    const nextReplacements = [...replacements];
+    nextReplacements[option.index] = sample;
+
+    return canDeclarationMatchWithoutOccurrence(
+      valueSource,
+      occurrences,
+      substitutionOptions,
+      matcher,
+      removedIndex,
+      optionIndex + 1,
+      nextReplacements,
+    );
+  });
+}
+
+function toPreciseMultiVarDiagnostic(
+  filePath: string,
+  declaration: any,
+  registeredEntries: Array<{ index: number; registration: RegisteredProperty; varNode: any }>,
+  valueSource: string,
+  occurrences: Array<{ end: number; start: number; varNode: any }>,
+  substitutionOptions: Array<{ index: number; samples: string[]; varNode: any }>,
+  matcher: (candidateValue: any) => boolean,
+): ValidationDiagnostic {
+  // For repeated or multi-var() values, we first ask a narrower question than
+  // "does the whole declaration fail?": if we drop exactly one occurrence and
+  // keep substituting representative samples for the rest, can the declaration
+  // become valid? A single surviving candidate gives us a precise culprit.
+  // Multiple candidates mean we should stay honest and report a possible culprit.
+  const candidateIndexes = registeredEntries
+    .filter((entry) =>
+      canDeclarationMatchWithoutOccurrence(
+        valueSource,
+        occurrences,
+        substitutionOptions,
+        matcher,
+        entry.index,
+      ),
+    )
+    .map((entry) => entry.index);
+
+  if (candidateIndexes.length === 1) {
+    const culprit = registeredEntries.find((entry) => entry.index === candidateIndexes[0]);
+
+    if (culprit) {
+      return toVarDiagnostic(filePath, declaration, [culprit.registration], [culprit.varNode]);
+    }
+  }
+
+  if (candidateIndexes.length > 1) {
+    const candidates = registeredEntries
+      .filter((entry) => candidateIndexes.includes(entry.index))
+      .map((entry) => entry.registration);
+
+    return toPossibleVarDiagnostic(filePath, declaration, candidates);
+  }
+
+  return toVarDiagnostic(
+    filePath,
+    declaration,
+    registeredEntries.map((entry) => entry.registration),
+    registeredEntries.map((entry) => entry.varNode),
   );
 }
 
@@ -260,9 +431,16 @@ function validateDeclaration(
     return { diagnostics, skipped: 1, validated: 0 };
   }
 
+  const valueSource = cssTree.generate(valueToValidate);
+  const occurrences = collectVarOccurrences(valueSource, registeredEntries.map((entry) => entry.varNode));
+
+  if (!occurrences) {
+    return { diagnostics, skipped: 1, validated: 0 };
+  }
+
   const substitutionOptions = [];
 
-  for (const entry of registeredEntries) {
+  for (const [index, entry] of registeredEntries.entries()) {
     let samples: string[];
 
     try {
@@ -277,6 +455,7 @@ function validateDeclaration(
     }
 
     substitutionOptions.push({
+      index,
       samples,
       varNode: entry.varNode,
     });
@@ -292,7 +471,12 @@ function validateDeclaration(
 
   // The declaration passes if all registered var() usages can be substituted
   // with one compatible combination of representative sample values.
-  const isCompatible = isCompatibleWithSubstitutions(valueToValidate, substitutionOptions, matcher);
+  const isCompatible = isCompatibleWithSubstitutions(
+    valueSource,
+    occurrences,
+    substitutionOptions,
+    matcher,
+  );
 
   if (!isCompatible) {
     if (isCustomPropertyName(declaration.property)) {
@@ -300,12 +484,19 @@ function validateDeclaration(
         toAssignmentDiagnostic(filePath, declaration, registry.get(declaration.property) as RegisteredProperty),
       );
     } else {
+      // When several registered var() calls participate in one declaration,
+      // prefer the narrowest truthful diagnostic we can support. If removing
+      // one occurrence isolates the failure, point at that occurrence; otherwise
+      // fall back to a possible-culprit or declaration-level message.
       diagnostics.push(
-        toVarDiagnostic(
+        toPreciseMultiVarDiagnostic(
           filePath,
           declaration,
-          registeredEntries.map((entry) => entry.registration),
-          registeredEntries.map((entry) => entry.varNode),
+          registeredEntries.map((entry, index) => ({ ...entry, index })),
+          valueSource,
+          occurrences,
+          substitutionOptions,
+          matcher,
         ),
       );
     }
@@ -331,7 +522,9 @@ export function validateFiles(
     registrySources.push(input);
   }
 
-  const registryResult = collectRegistry(registrySources);
+  const registryResult = collectRegistry(registrySources, {
+    resolveImport: options.resolveImport,
+  });
   const diagnostics = [...registryResult.diagnostics];
   const registry = registryMap(registryResult.registry);
   let skippedDeclarations = 0;

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -23,6 +23,16 @@ function runValidation(cssByPath: Record<string, string>) {
   );
 }
 
+function createTestResolver(cssByPath: Record<string, string>) {
+  return (specifier: string, fromPath: string) => {
+    const resolvedPath = specifier.startsWith("/")
+      ? specifier
+      : path.posix.resolve(path.posix.dirname(fromPath), specifier);
+
+    return resolvedPath in cssByPath ? { path: resolvedPath, css: cssByPath[resolvedPath] } : null;
+  };
+}
+
 describe("validateFiles", () => {
   it("accepts a compatible var() usage from a registration in another file", () => {
     const result = runValidation({
@@ -374,10 +384,12 @@ describe("validateFiles", () => {
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
     expect(result.diagnostics[0]?.expectedProperty).toBe("margin");
+    expect(result.diagnostics[0]?.propertyName).toBe("--brand-color");
+    expect(result.diagnostics[0]?.message).toContain("at this var() usage");
     expect(result.validatedDeclarations).toBe(1);
   });
 
-  it("reports incompatible shorthand-like declarations with multiple registered custom properties", () => {
+  it("reports possible culprits for ambiguous shorthand-like declarations", () => {
     const result = runValidation({
       "/tmp/registry.css": SHARED_REGISTRY,
       "/tmp/usage.css": ".card { border: var(--brand-color) solid var(--brand-color); }",
@@ -387,12 +399,29 @@ describe("validateFiles", () => {
     expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
     expect(result.diagnostics[0]?.expectedProperty).toBe("border");
     expect(result.diagnostics[0]?.message).toContain(
-      "Registered properties --brand-color are jointly incompatible with border",
+      "One or more var() usages of registered property --brand-color may be incompatible with border",
     );
     expect(result.diagnostics[0]?.message).not.toContain("--brand-color, --brand-color");
+    expect(result.diagnostics[0]?.propertyName).toBeUndefined();
     expect(result.diagnostics[0]?.snippet).toBe(
       "border:var(--brand-color) solid var(--brand-color)",
     );
+  });
+
+  it("falls back to a declaration-level diagnostic when no single var() removal isolates the mismatch", () => {
+    const result = runValidation({
+      "/tmp/registry.css":
+        '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+      "/tmp/usage.css": ".card { margin: var(--brand-color) var(--brand-color); }",
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.diagnostics[0]?.expectedProperty).toBe("margin");
+    expect(result.diagnostics[0]?.message).toContain(
+      "Registered properties --brand-color are jointly incompatible with margin",
+    );
+    expect(result.diagnostics[0]?.propertyName).toBeUndefined();
   });
 
   it("accepts repeated use of the same registered custom property in one declaration", () => {
@@ -500,6 +529,175 @@ describe("validateFiles", () => {
     expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
   });
 
+  it("uses imports from validation inputs when assembling the registry", () => {
+    const cssByPath = {
+      "/tmp/main.css": '@import "./tokens.css";\n.card { inline-size: var(--space); }',
+      "/tmp/tokens.css":
+        '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+    };
+
+    const result = validateFiles(
+      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
+      { resolveImport: createTestResolver(cssByPath) },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.filePath).toBe("/tmp/tokens.css");
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("follows nested imports from registry-only inputs", () => {
+    const cssByPath = {
+      "/tmp/component.css": ".card { inline-size: var(--space); }",
+      "/tmp/registry.css": '@import "./tokens.css";',
+      "/tmp/tokens.css":
+        '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+    };
+
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: cssByPath["/tmp/component.css"] }],
+      {
+        registryInputs: [{ path: "/tmp/registry.css", css: cssByPath["/tmp/registry.css"] }],
+        resolveImport: createTestResolver(cssByPath),
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.filePath).toBe("/tmp/tokens.css");
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("resolves root-relative imports through the resolver policy", () => {
+    const cssByPath = {
+      "/tmp/main.css": '@import "/tokens/root.css";\n.card { background-image: var(--hero-url); }',
+      "/tokens/root.css":
+        '@property --hero-url { syntax: "<url>"; inherits: false; initial-value: url("https://example.com/hero.png"); }',
+    };
+
+    const result = validateFiles(
+      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
+      { resolveImport: createTestResolver(cssByPath) },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry[0]?.filePath).toBe("/tokens/root.css");
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("treats imported files as registry sources rather than additional validation targets", () => {
+    const cssByPath = {
+      "/tmp/main.css": '@import "./tokens.css";\n.card { color: var(--brand-color); }',
+      "/tmp/tokens.css": [
+        '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+        ".tokens { inline-size: var(--brand-color); }",
+      ].join("\n"),
+    };
+
+    const result = validateFiles(
+      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
+      { resolveImport: createTestResolver(cssByPath) },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("preserves last-valid-registration-wins precedence across import boundaries", () => {
+    const cssByPath = {
+      "/tmp/main.css": [
+        '@import "./theme.css";',
+        '@property --surface-token { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+        ".card { color: var(--surface-token); }",
+      ].join("\n"),
+      "/tmp/theme.css":
+        '@property --surface-token { syntax: "<color>"; inherits: true; initial-value: white; }',
+    };
+
+    const result = validateFiles(
+      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
+      { resolveImport: createTestResolver(cssByPath) },
+    );
+
+    expect(result.registry).toHaveLength(1);
+    expect(result.registry[0]?.filePath).toBe("/tmp/main.css");
+    expect(result.registry[0]?.syntax).toBe("<length>");
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.expectedProperty).toBe("color");
+  });
+
+  it("handles cyclic import graphs without infinite recursion or duplicate registry entries", () => {
+    const cssByPath = {
+      "/tmp/main.css": '@import "./a.css";\n.card { inline-size: var(--space); }',
+      "/tmp/a.css": '@import "./b.css";',
+      "/tmp/b.css": [
+        '@import "./a.css";',
+        '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+      ].join("\n"),
+    };
+
+    const result = validateFiles(
+      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
+      { resolveImport: createTestResolver(cssByPath) },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(1);
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("skips absolute URL imports when assembling the registry", () => {
+    const result = validateFiles(
+      [
+        {
+          path: "/tmp/main.css",
+          css: '@import "https://example.com/tokens.css";\n.card { inline-size: var(--space); }',
+        },
+      ],
+      {
+        resolveImport: () => {
+          throw new Error("remote imports should be skipped before resolution");
+        },
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it("skips conditioned imports when assembling the registry", () => {
+    const result = validateFiles(
+      [
+        {
+          path: "/tmp/main.css",
+          css: '@import "./tokens.css" screen;\n.card { inline-size: var(--space); }',
+        },
+      ],
+      {
+        resolveImport: () => {
+          throw new Error("conditioned imports should be skipped before resolution");
+        },
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.registry).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it("reports unresolved local imports", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/main.css", css: '@import "./missing.css";\n.card { color: red; }' }],
+      { resolveImport: () => null },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("unresolved-import");
+    expect(result.diagnostics[0]?.message).toContain("./missing.css");
+  });
+
   it("treats registry-only files as registration sources, not validation targets", () => {
     const result = validateFiles(
       [{ path: "/tmp/component.css", css: ".card { color: var(--brand-color); }" }],
@@ -560,7 +758,7 @@ describe("validateFiles", () => {
 
     const cliResult = spawnSync(
       "node",
-      ["packages/cli/dist/cli.js", "example.css", "--format", "json"],
+      ["packages/cli/dist/cli.js", "fixtures/imports/main.css", "--format", "json"],
       {
         cwd: repoRoot,
         encoding: "utf8",
@@ -573,6 +771,7 @@ describe("validateFiles", () => {
       diagnostics: Array<{
         code: string;
         expectedProperty?: string;
+        message: string;
         propertyName?: string;
         snippet?: string;
       }>;
@@ -580,7 +779,7 @@ describe("validateFiles", () => {
       validatedDeclarations: number;
     };
 
-    expect(report.diagnostics).toHaveLength(13);
+    expect(report.diagnostics).toHaveLength(20);
     expect(report.diagnostics.some((diagnostic) => diagnostic.code === "invalid-property-registration")).toBe(
       true,
     );
@@ -591,7 +790,7 @@ describe("validateFiles", () => {
       report.diagnostics.some(
         (diagnostic) =>
           diagnostic.code === "invalid-property-registration" &&
-          diagnostic.propertyName === "--space-md",
+          diagnostic.propertyName === "--relative-space",
       ),
     ).toBe(true);
     expect(
@@ -611,8 +810,15 @@ describe("validateFiles", () => {
         (diagnostic) => diagnostic.snippet === "margin-inline:var(--brand-color) var(--radius-lg)",
       ),
     ).toBe(true);
-    expect(report.skippedDeclarations).toBe(4);
-    expect(report.validatedDeclarations).toBe(15);
+    expect(
+      report.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.snippet === "border:var(--brand-color) solid var(--brand-color)" &&
+          diagnostic.message.includes("may be incompatible"),
+      ),
+    ).toBe(true);
+    expect(report.skippedDeclarations).toBe(0);
+    expect(report.validatedDeclarations).toBe(30);
   });
 
   it("supports registry-only CLI inputs", { timeout: 120000 }, () => {
@@ -728,5 +934,66 @@ describe("validateFiles", () => {
     expect(report.diagnostics[0]?.code).toBe("invalid-property-registration");
     expect(report.diagnostics[0]?.filePath).toBe(registryPath);
     expect(report.validatedDeclarations).toBe(0);
+  });
+
+  it("follows local imports automatically in CLI mode", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const validationPath = path.join(fixtureDir, "component.css");
+    const registryPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(validationPath, '@import "./tokens.css";\n.card { inline-size: var(--space); }\n');
+    writeFileSync(
+      registryPath,
+      '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }\n',
+    );
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", validationPath, "--format", "json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(0);
+
+    const report = JSON.parse(cliResult.stdout) as {
+      diagnostics: Array<{ code: string }>;
+      registry: Array<{ filePath: string }>;
+      validatedDeclarations: number;
+    };
+
+    expect(report.diagnostics).toHaveLength(0);
+    expect(report.registry[0]?.filePath).toBe(registryPath);
+    expect(report.validatedDeclarations).toBe(1);
+  });
+
+  it("includes unresolved-import diagnostics in CLI output", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const validationPath = path.join(fixtureDir, "component.css");
+
+    writeFileSync(validationPath, '@import "./missing.css";\n.card { color: red; }\n');
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", validationPath, "--format", "json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(1);
+
+    const report = JSON.parse(cliResult.stdout) as {
+      diagnostics: Array<{ code: string; message: string }>;
+    };
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]?.code).toBe("unresolved-import");
+    expect(report.diagnostics[0]?.message).toContain("./missing.css");
   });
 });


### PR DESCRIPTION
## Summary
- follow local unconditioned @import rules while assembling the @property registry
- add fixture-based examples, tests, and docs for supported and intentionally unsupported import cases
- expose a core import resolver hook and surface unresolved local imports as diagnostics

## Testing
- pnpm run typecheck
- pnpm test
- pnpm run build

## Follow-ups
- #32 browser-aligned @import and CSSOM research
- #33 optional import-aware full validation for imported stylesheets

Closes #20