### PR TITLE
feat(cli): add explicit registration-only mode for @property validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ console.log(result.diagnostics);
 css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
+css-property-type-validator "src/tokens/**/*.css" --registry-only
 css-property-type-validator "fixtures/imports/main.css"
 ```
 
@@ -226,6 +227,14 @@ css-property-type-validator "src/components/**/*.css" --registry "src/tokens/**/
 ```
 
 Registry-only files contribute `@property` registrations and any registration/parse diagnostics, but their own normal declarations are not validated unless you also pass them as main inputs.
+
+When you want to validate registrations on their own, use the explicit registration-only mode:
+
+```bash
+css-property-type-validator "src/tokens/**/*.css" --registry-only
+```
+
+In `--registry-only` mode, the positional patterns are treated as registration sources rather than normal declaration-validation targets.
 
 When a resolver is available, the validator also follows local unconditioned `@import` rules while assembling the registry. That includes relative imports and root-relative imports in the CLI. Remote imports and conditioned imports remain intentionally out of scope for now.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -22,6 +22,7 @@ npx @schalkneethling/css-property-type-validator-cli "src/**/*.css"
 css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
+css-property-type-validator "src/tokens/**/*.css" --registry-only
 css-property-type-validator "fixtures/imports/main.css"
 ```
 
@@ -34,6 +35,14 @@ css-property-type-validator "src/**/*.css" \
 ```
 
 Registry-only files still report parse errors and invalid `@property` registrations. The CLI also follows local unconditioned `@import` rules automatically while assembling the registry, including relative and root-relative imports. Remote and conditioned imports are still out of scope for now.
+
+Use `--registry-only` when you want to validate `@property` rules without also validating ordinary declarations from those files:
+
+```bash
+css-property-type-validator "src/tokens/**/*.css" --registry-only
+```
+
+In `--registry-only` mode, the positional patterns become registration sources instead of normal validation targets. You can still add extra shared registry inputs with `--registry` when needed.
 
 ## Exit codes
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -131,14 +131,6 @@ async function main(): Promise<void> {
         return;
       }
 
-      if (patterns.length === 0) {
-        process.stderr.write(
-          "No validation patterns were provided. Pass CSS files or glob patterns to validate, or use --registry-only for registration-only validation.\n",
-        );
-        process.exitCode = 2;
-        return;
-      }
-
       const inputs = await loadInputs(patterns);
 
       if (inputs.length === 0) {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -70,13 +70,17 @@ async function loadRegistryInputs(
   return registryInputs.filter((input) => !validationPaths.has(input.path));
 }
 
+function resolveOutputFormat(format: string): OutputFormat {
+  return format === "json" ? "json" : "human";
+}
+
 async function main(): Promise<void> {
   const program = new Command();
 
   program
     .name("css-property-type-validator")
     .description("Validate @property registrations and var() usages across CSS files.")
-    .argument("<patterns...>", "CSS files or glob patterns to validate")
+    .argument("[patterns...]", "CSS files or glob patterns to validate")
     .option("-f, --format <format>", "output format: human or json", "human")
     .option(
       "-r, --registry <pattern>",
@@ -84,8 +88,57 @@ async function main(): Promise<void> {
       (value: string, previous: string[] = []) => [...previous, value],
       [],
     )
-    .action(async (patterns: string[], options: { format: OutputFormat; registry: string[] }) => {
-      const format = options.format === "json" ? "json" : "human";
+    .option(
+      "--registry-only",
+      "validate @property registrations from the provided input patterns without validating ordinary declarations",
+      false,
+    )
+    .action(
+      async (
+        patterns: string[],
+        options: { format: OutputFormat; registry: string[]; registryOnly: boolean },
+      ) => {
+      const format = resolveOutputFormat(options.format);
+
+      if (options.registryOnly) {
+        if (patterns.length === 0) {
+          process.stderr.write(
+            "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
+          );
+          process.exitCode = 2;
+          return;
+        }
+
+        const registryInputs = await loadInputs(patterns);
+
+        if (registryInputs.length === 0) {
+          process.stderr.write(
+            "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
+          );
+          process.exitCode = 2;
+          return;
+        }
+
+        const additionalRegistryInputs = await loadRegistryInputs(options.registry, registryInputs);
+        const result = validateFiles([], {
+          registryInputs: [...registryInputs, ...additionalRegistryInputs],
+          resolveImport: createImportResolver(process.cwd()),
+        });
+        const output = formatValidationResult(result, format);
+
+        process.stdout.write(`${output}\n`);
+        process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
+        return;
+      }
+
+      if (patterns.length === 0) {
+        process.stderr.write(
+          "No validation patterns were provided. Pass CSS files or glob patterns to validate, or use --registry-only for registration-only validation.\n",
+        );
+        process.exitCode = 2;
+        return;
+      }
+
       const inputs = await loadInputs(patterns);
 
       if (inputs.length === 0) {
@@ -105,7 +158,8 @@ async function main(): Promise<void> {
 
       process.stdout.write(`${output}\n`);
       process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
-    });
+      },
+    );
 
   await program.parseAsync(process.argv);
 }

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -863,7 +863,7 @@ describe("validateFiles", () => {
     expect(report.validatedDeclarations).toBe(1);
   });
 
-  it("returns exit code 2 when only registry inputs match", { timeout: 120000 }, () => {
+  it("supports explicit registration-only CLI mode", { timeout: 120000 }, () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../..");
     const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
     const registryPath = path.join(fixtureDir, "tokens.css");
@@ -877,9 +877,79 @@ describe("validateFiles", () => {
       "node",
       [
         "packages/cli/dist/cli.js",
-        path.join(fixtureDir, "missing-*.css"),
-        "--registry",
         registryPath,
+        "--registry-only",
+        "--format",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(0);
+
+    const report = JSON.parse(cliResult.stdout) as {
+      diagnostics: Array<{ code: string }>;
+      registry: Array<{ filePath: string }>;
+      validatedDeclarations: number;
+    };
+
+    expect(report.diagnostics).toHaveLength(0);
+    expect(report.registry).toHaveLength(1);
+    expect(report.registry[0]?.filePath).toBe(registryPath);
+    expect(report.validatedDeclarations).toBe(0);
+  });
+
+  it("reports invalid registrations in explicit registration-only CLI mode", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const registryPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(
+      registryPath,
+      '@property --bad { syntax: "<color"; inherits: true; initial-value: transparent; }\n',
+    );
+
+    const cliResult = spawnSync(
+      "node",
+      [
+        "packages/cli/dist/cli.js",
+        registryPath,
+        "--registry-only",
+        "--format",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(1);
+
+    const report = JSON.parse(cliResult.stdout) as {
+      diagnostics: Array<{ code: string; filePath: string }>;
+      validatedDeclarations: number;
+    };
+
+    expect(report.diagnostics).toHaveLength(1);
+    expect(report.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(report.diagnostics[0]?.filePath).toBe(registryPath);
+    expect(report.validatedDeclarations).toBe(0);
+  });
+
+  it("returns exit code 2 when registration-only patterns do not match", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+
+    const cliResult = spawnSync(
+      "node",
+      [
+        "packages/cli/dist/cli.js",
+        path.join(fixtureDir, "missing-*.css"),
+        "--registry-only",
         "--format",
         "json",
       ],
@@ -891,7 +961,25 @@ describe("validateFiles", () => {
 
     expect(cliResult.status).toBe(2);
     expect(cliResult.stderr).toContain(
-      "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.",
+      "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.",
+    );
+  });
+
+  it("returns exit code 2 when no validation patterns are provided without --registry-only", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", "--format", "json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(2);
+    expect(cliResult.stderr).toContain(
+      "No validation patterns were provided. Pass CSS files or glob patterns to validate, or use --registry-only for registration-only validation.",
     );
   });
 

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -965,7 +965,7 @@ describe("validateFiles", () => {
     );
   });
 
-  it("returns exit code 2 when no validation patterns are provided without --registry-only", { timeout: 120000 }, () => {
+  it("returns the normal validation-input error when no validation patterns are provided", { timeout: 120000 }, () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../..");
 
     const cliResult = spawnSync(
@@ -979,7 +979,7 @@ describe("validateFiles", () => {
 
     expect(cliResult.status).toBe(2);
     expect(cliResult.stderr).toContain(
-      "No validation patterns were provided. Pass CSS files or glob patterns to validate, or use --registry-only for registration-only validation.",
+      "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.",
     );
   });
 


### PR DESCRIPTION
## Summary

This PR adds an explicit `--registry-only` CLI mode for validating `@property` registrations without requiring unrelated declaration-validation inputs.

## What Changed

- add `--registry-only` to the CLI
- treat positional patterns as registration sources in registration-only mode
- keep the existing validation flow unchanged for normal CLI usage
- document the new mode in the root README and CLI README
- add end-to-end CLI tests for:
  - successful registration-only validation
  - invalid registration diagnostics in registration-only mode
  - exit-code behavior when registration-only patterns do not match
- apply the review follow-up so the normal validation path reuses the existing missing-input error instead of introducing a mode-specific one

## Why

The validator can already surface registration diagnostics from registry-only sources, but doing registration validation on its own still felt incidental because the CLI required normal validation targets. This makes registration-only validation an explicit, intentional workflow.

## Validation

- `npm run build`
- `pnpm test`
