### PR TITLE
feat(core): validate simple var() fallback branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Standalone tooling for validating CSS custom property registrations declared wit
 - Builds a registry from `@property` rules across multiple input files
 - Validates `syntax` descriptors in those registrations
 - Checks `var()` declaration values against the consuming CSS property, including coordinated multi-`var()` cases
+- Validates simple fallback branches in `var(--token, fallback)` against the consuming property
 - Validates authored values assigned directly to registered custom properties
 - Ignores unregistered custom properties
 - Ships a standalone core package and a thin CLI wrapper

--- a/fixtures/imports/main.css
+++ b/fixtures/imports/main.css
@@ -19,6 +19,7 @@
   background-image: var(--hero-url);
   color: var(--brand-color);
   padding-inline: var(--space-md);
+  border-color: var(--brand-color, rebeccapurple);
 }
 
 /*
@@ -37,6 +38,7 @@
 .card--broken {
   inline-size: var(--brand-color);
   color: var(--space-md);
+  border-color: var(--brand-color, 10px);
   margin-inline: var(--brand-color) var(--space-md);
   border-end-end-radius: var(--fast-transition);
   border: var(--brand-color) solid var(--brand-color);

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Core validation engine for CSS Property Type Validator.
 
-This package reads CSS `@property` registrations, builds a registry of typed custom properties, validates compatible `var()` usage against consuming CSS properties, and checks authored assignments to registered custom properties.
+This package reads CSS `@property` registrations, builds a registry of typed custom properties, validates compatible `var()` usage against consuming CSS properties, validates simple `var()` fallback branches against consuming CSS properties, and checks authored assignments to registered custom properties.
 
 ## Install
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -16,6 +16,31 @@ export interface ValidateFilesOptions {
   resolveImport?: ResolveImport;
 }
 
+type CssValueAst = any;
+type CssNodeWithLoc = { loc?: any; name?: string; type?: string; value?: string };
+type CssNodeList<TNode> = { first?: TNode; toArray?: () => TNode[] };
+type VarFunctionNode = {
+  children?: CssNodeList<CssNodeWithLoc> | CssNodeWithLoc[];
+  loc?: any;
+  name?: string;
+};
+type VarOccurrence = { end: number; start: number; varNode: VarFunctionNode };
+type SubstitutionOption = { index: number; samples: string[]; varNode: VarFunctionNode };
+type ActiveSubstitution = { sample: string; varNode: VarFunctionNode };
+type Matcher = (candidateValue: CssValueAst) => boolean;
+type ReplacementCheckContext = {
+  matcher: Matcher;
+  occurrences: VarOccurrence[];
+  substitutionOptions: SubstitutionOption[];
+  valueSource: string;
+};
+type FallbackEntry = {
+  fallbackSource: string;
+  index: number;
+  registration: RegisteredProperty;
+  varNode: VarFunctionNode;
+};
+
 function toLocation(loc: any): ValidationDiagnostic["loc"] {
   return loc
     ? {
@@ -57,12 +82,39 @@ function getDeclarationValueForValidation(declaration: any): any | null {
   return declaration.value;
 }
 
-function getVarPropertyName(node: any): string | undefined {
-  const firstNode = node.children?.first ?? node.children?.[0];
+function getVarChildren(node: VarFunctionNode): CssNodeWithLoc[] {
+  if (Array.isArray(node.children)) {
+    return node.children;
+  }
+
+  return node.children?.toArray?.() ?? [];
+}
+
+function getVarPropertyName(node: VarFunctionNode): string | undefined {
+  const firstNode = Array.isArray(node.children) ? node.children[0] : node.children?.first;
   return firstNode?.type === "Identifier" ? firstNode.name : undefined;
 }
 
-function parseValue(value: string): any | null {
+function getVarFallbackSource(node: VarFunctionNode): string | null {
+  const children = getVarChildren(node);
+  const fallbackStartIndex = children.findIndex(
+    (child) => child.type === "Operator" && child.value === ",",
+  );
+
+  if (fallbackStartIndex === -1) {
+    return null;
+  }
+
+  const fallbackSource = children
+    .slice(fallbackStartIndex + 1)
+    .map((child) => cssTree.generate(child))
+    .join("")
+    .trim();
+
+  return fallbackSource.length > 0 ? fallbackSource : null;
+}
+
+function parseValue(value: string): CssValueAst | null {
   try {
     return cssTree.parse(value, { context: "value" });
   } catch {
@@ -81,8 +133,8 @@ function matchRegisteredSyntax(registration: RegisteredProperty, value: any): bo
 
 function collectVarOccurrences(
   valueSource: string,
-  varNodes: any[],
-): Array<{ end: number; start: number; varNode: any }> | null {
+  varNodes: VarFunctionNode[],
+): VarOccurrence[] | null {
   const occurrences = [];
   let searchStart = 0;
 
@@ -105,7 +157,7 @@ function collectVarOccurrences(
 
 function renderValueWithReplacements(
   valueSource: string,
-  occurrences: Array<{ end: number; start: number; varNode: any }>,
+  occurrences: VarOccurrence[],
   replacements: Array<string | null>,
 ): string {
   let rendered = "";
@@ -124,7 +176,7 @@ function renderValueWithReplacements(
 
 function valueMatchesRenderedSource(
   renderedSource: string,
-  matcher: (candidateValue: any) => boolean,
+  matcher: Matcher,
 ): boolean {
   const replacedAst = parseValue(renderedSource);
 
@@ -137,9 +189,9 @@ function valueMatchesRenderedSource(
 
 function valueMatchesSamples(
   valueSource: string,
-  occurrences: Array<{ end: number; start: number; varNode: any }>,
-  substitutions: Array<{ sample: string; varNode: any }>,
-  matcher: (candidateValue: any) => boolean,
+  occurrences: VarOccurrence[],
+  substitutions: ActiveSubstitution[],
+  matcher: Matcher,
 ): boolean {
   const replacementMap = new Map(substitutions.map((substitution) => [substitution.varNode, substitution.sample]));
   const renderedSource = renderValueWithReplacements(
@@ -155,7 +207,7 @@ function toVarDiagnostic(
   filePath: string,
   declaration: any,
   registrations: RegisteredProperty[],
-  varNodes: any[],
+  varNodes: VarFunctionNode[],
 ): ValidationDiagnostic {
   if (registrations.length === 1) {
     const [registration] = registrations;
@@ -224,13 +276,31 @@ function toAssignmentDiagnostic(
   };
 }
 
+function toFallbackDiagnostic(
+  filePath: string,
+  declaration: any,
+  registration: RegisteredProperty,
+  varNode: VarFunctionNode,
+): ValidationDiagnostic {
+  return {
+    code: "incompatible-var-usage",
+    filePath,
+    loc: toLocation(varNode.loc),
+    message: `Fallback value in var() for registered property ${registration.name} is incompatible with ${declaration.property} at this var() usage.`,
+    propertyName: registration.name,
+    registeredSyntax: registration.syntax,
+    expectedProperty: declaration.property,
+    snippet: cssTree.generate(declaration),
+  };
+}
+
 function isCompatibleWithSubstitutions(
   valueSource: string,
-  occurrences: Array<{ end: number; start: number; varNode: any }>,
-  substitutionOptions: Array<{ samples: string[]; varNode: any }>,
-  matcher: (candidateValue: any) => boolean,
+  occurrences: VarOccurrence[],
+  substitutionOptions: Array<{ samples: string[]; varNode: VarFunctionNode }>,
+  matcher: Matcher,
   index = 0,
-  activeSubstitutions: Array<{ sample: string; varNode: any }> = [],
+  activeSubstitutions: ActiveSubstitution[] = [],
 ): boolean {
   if (index === substitutionOptions.length) {
     return valueMatchesSamples(valueSource, occurrences, activeSubstitutions, matcher);
@@ -248,9 +318,9 @@ function isCompatibleWithSubstitutions(
 
 function canDeclarationMatchWithoutOccurrence(
   valueSource: string,
-  occurrences: Array<{ end: number; start: number; varNode: any }>,
-  substitutionOptions: Array<{ index: number; samples: string[]; varNode: any }>,
-  matcher: (candidateValue: any) => boolean,
+  occurrences: VarOccurrence[],
+  substitutionOptions: SubstitutionOption[],
+  matcher: Matcher,
   removedIndex: number,
   optionIndex = 0,
   replacements: Array<string | null> = Array.from({ length: occurrences.length }, () => null),
@@ -290,14 +360,63 @@ function canDeclarationMatchWithoutOccurrence(
   });
 }
 
+// This helper answers a narrower fallback-specific question than the normal
+// representative-sample check: if one var() occurrence resolves to its authored
+// fallback branch while the other registered occurrences keep using compatible
+// samples, can the full declaration still match the consuming property?
+function canDeclarationMatchWithOccurrenceReplacement(
+  context: ReplacementCheckContext,
+  replacedIndex: number,
+  replacementSource: string,
+  optionIndex = 0,
+  replacements: Array<string | null> = Array.from({ length: context.occurrences.length }, () => null),
+): boolean {
+  if (optionIndex === context.substitutionOptions.length) {
+    const renderedSource = renderValueWithReplacements(
+      context.valueSource,
+      context.occurrences,
+      replacements,
+    );
+    return valueMatchesRenderedSource(renderedSource, context.matcher);
+  }
+
+  const option = context.substitutionOptions[optionIndex];
+
+  if (option.index === replacedIndex) {
+    const nextReplacements = [...replacements];
+    nextReplacements[replacedIndex] = replacementSource;
+
+    return canDeclarationMatchWithOccurrenceReplacement(
+      context,
+      replacedIndex,
+      replacementSource,
+      optionIndex + 1,
+      nextReplacements,
+    );
+  }
+
+  return option.samples.some((sample) => {
+    const nextReplacements = [...replacements];
+    nextReplacements[option.index] = sample;
+
+    return canDeclarationMatchWithOccurrenceReplacement(
+      context,
+      replacedIndex,
+      replacementSource,
+      optionIndex + 1,
+      nextReplacements,
+    );
+  });
+}
+
 function toPreciseMultiVarDiagnostic(
   filePath: string,
   declaration: any,
-  registeredEntries: Array<{ index: number; registration: RegisteredProperty; varNode: any }>,
+  registeredEntries: Array<{ index: number; registration: RegisteredProperty; varNode: VarFunctionNode }>,
   valueSource: string,
-  occurrences: Array<{ end: number; start: number; varNode: any }>,
-  substitutionOptions: Array<{ index: number; samples: string[]; varNode: any }>,
-  matcher: (candidateValue: any) => boolean,
+  occurrences: VarOccurrence[],
+  substitutionOptions: SubstitutionOption[],
+  matcher: Matcher,
 ): ValidationDiagnostic {
   // For repeated or multi-var() values, we first ask a narrower question than
   // "does the whole declaration fail?": if we drop exactly one occurrence and
@@ -431,6 +550,15 @@ function validateDeclaration(
     return { diagnostics, skipped: 1, validated: 0 };
   }
 
+  // Fallback handling for assignment-site var() usage is intentionally deferred.
+  // For now we only validate fallback branches against ordinary consuming properties.
+  if (
+    isCustomPropertyName(declaration.property) &&
+    registeredEntries.some((entry) => getVarFallbackSource(entry.varNode) !== null)
+  ) {
+    return { diagnostics, skipped: 1, validated: 0 };
+  }
+
   const valueSource = cssTree.generate(valueToValidate);
   const occurrences = collectVarOccurrences(valueSource, registeredEntries.map((entry) => entry.varNode));
 
@@ -469,6 +597,35 @@ function validateDeclaration(
         return Boolean(match?.matched);
       };
 
+  const fallbackEntries: FallbackEntry[] = [];
+
+  for (const [index, entry] of registeredEntries.entries()) {
+    const fallbackSource = getVarFallbackSource(entry.varNode);
+
+    if (!fallbackSource) {
+      continue;
+    }
+
+    const fallbackValue = parseValue(fallbackSource);
+
+    if (!fallbackValue) {
+      return { diagnostics, skipped: 1, validated: 0 };
+    }
+
+    // Nested var() fallback chains are valid CSS, but we skip them for now until
+    // the validator can model fallback reachability without overclaiming certainty.
+    if (collectVarFunctions(fallbackValue).length > 0) {
+      return { diagnostics, skipped: 1, validated: 0 };
+    }
+
+    fallbackEntries.push({
+      fallbackSource,
+      index,
+      registration: entry.registration,
+      varNode: entry.varNode,
+    });
+  }
+
   // The declaration passes if all registered var() usages can be substituted
   // with one compatible combination of representative sample values.
   const isCompatible = isCompatibleWithSubstitutions(
@@ -477,6 +634,31 @@ function validateDeclaration(
     substitutionOptions,
     matcher,
   );
+  const fallbackReplacementContext: ReplacementCheckContext = {
+    matcher,
+    occurrences,
+    substitutionOptions,
+    valueSource,
+  };
+
+  for (const fallbackEntry of fallbackEntries) {
+    const isFallbackCompatible = canDeclarationMatchWithOccurrenceReplacement(
+      fallbackReplacementContext,
+      fallbackEntry.index,
+      fallbackEntry.fallbackSource,
+    );
+
+    if (!isFallbackCompatible) {
+      diagnostics.push(
+        toFallbackDiagnostic(
+          filePath,
+          declaration,
+          fallbackEntry.registration,
+          fallbackEntry.varNode,
+        ),
+      );
+    }
+  }
 
   if (!isCompatible) {
     if (isCustomPropertyName(declaration.property)) {

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -347,6 +347,59 @@ describe("validateFiles", () => {
     expect(result.validatedDeclarations).toBe(2);
   });
 
+  it("reports an incompatible fallback value for a registered var() usage", () => {
+    const result = runValidation({
+      "/tmp/tokens.css": SHARED_REGISTRY,
+      "/tmp/component.css": '.card { color: var(--brand-color, 10px); }',
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.diagnostics[0]?.message).toContain("Fallback value in var()");
+    expect(result.diagnostics[0]?.message).toContain("--brand-color");
+    expect(result.diagnostics[0]?.expectedProperty).toBe("color");
+    expect(result.validatedDeclarations).toBe(1);
+    expect(result.skippedDeclarations).toBe(0);
+  });
+
+  it("reports an incompatible fallback branch within a multi-var() declaration", () => {
+    const result = runValidation({
+      "/tmp/tokens.css": SHARED_REGISTRY,
+      "/tmp/component.css":
+        ".card { border: var(--border-width, red) solid var(--brand-color, rebeccapurple); }",
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.diagnostics[0]?.message).toContain("Fallback value in var()");
+    expect(result.diagnostics[0]?.message).toContain("--border-width");
+    expect(result.diagnostics[0]?.expectedProperty).toBe("border");
+    expect(result.validatedDeclarations).toBe(1);
+    expect(result.skippedDeclarations).toBe(0);
+  });
+
+  it("skips assignment-site fallback validation for now", () => {
+    const result = runValidation({
+      "/tmp/tokens.css": SHARED_REGISTRY,
+      "/tmp/component.css": ':root { --space-md: var(--space-sm, red); }',
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+    expect(result.skippedDeclarations).toBe(1);
+  });
+
+  it("skips nested fallback chains until fallback reachability is modeled", () => {
+    const result = runValidation({
+      "/tmp/tokens.css": SHARED_REGISTRY,
+      "/tmp/component.css": '.card { color: var(--brand-color, var(--accent-color, blue)); }',
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+    expect(result.skippedDeclarations).toBe(1);
+  });
+
   it("accepts compatible declarations with multiple var() usages", () => {
     const result = runValidation({
       "/tmp/registry.css": [
@@ -779,7 +832,7 @@ describe("validateFiles", () => {
       validatedDeclarations: number;
     };
 
-    expect(report.diagnostics).toHaveLength(20);
+    expect(report.diagnostics).toHaveLength(21);
     expect(report.diagnostics.some((diagnostic) => diagnostic.code === "invalid-property-registration")).toBe(
       true,
     );
@@ -813,12 +866,19 @@ describe("validateFiles", () => {
     expect(
       report.diagnostics.some(
         (diagnostic) =>
+          diagnostic.snippet === "border-color:var(--brand-color, 10px)" &&
+          diagnostic.message.includes("Fallback value in var()"),
+      ),
+    ).toBe(true);
+    expect(
+      report.diagnostics.some(
+        (diagnostic) =>
           diagnostic.snippet === "border:var(--brand-color) solid var(--brand-color)" &&
           diagnostic.message.includes("may be incompatible"),
       ),
     ).toBe(true);
     expect(report.skippedDeclarations).toBe(0);
-    expect(report.validatedDeclarations).toBe(30);
+    expect(report.validatedDeclarations).toBe(32);
   });
 
   it("supports registry-only CLI inputs", { timeout: 120000 }, () => {


### PR DESCRIPTION
## Summary

This PR adds conservative fallback validation for `var(--token, fallback)` usage in ordinary declarations.

Closes #16.

## What Changed

- validate simple fallback branches in `var()` against the consuming property
- keep fallback validation scoped to ordinary declarations for now
- skip assignment-site fallback validation until that behavior is modeled more explicitly
- skip nested fallback chains such as `var(--a, var(--b, blue))` to avoid overclaiming certainty
- add targeted tests for valid fallbacks, invalid fallbacks, multi-`var()` fallback cases, and current skip boundaries
- update the shared fixture CSS and smoke test so end-to-end coverage includes fallback behavior
- document fallback validation in the root and core READMEs
- tighten the fallback helper types and refactor the replacement helper to use a smaller context object after review feedback

## Why

The validator already checks the primary registered custom-property branch in `var()` usage, but the fallback branch can also encode real author intent. Validating simple fallbacks closes a practical correctness gap without taking on the larger computed-value-time modeling work yet.

## Validation

- `npm run build`
- `pnpm test`
