### PR TITLE
chore: improve contributor DX stocktake

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Check formatting
+        run: pnpm run format:check
+
+      - name: Lint
+        run: pnpm run lint
+
       - name: Typecheck
         run: pnpm run typecheck
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,59 @@
+# Contributing
+
+Thanks for helping improve CSS Property Type Validator.
+
+## Setup
+
+This repository uses pnpm workspaces and requires Node.js 22 or newer.
+
+```bash
+pnpm install
+pnpm run build
+pnpm test
+```
+
+## Quick Feedback
+
+Use these commands while developing:
+
+```bash
+pnpm run format
+pnpm run format:check
+pnpm run lint
+pnpm run typecheck
+pnpm test
+pnpm run build
+pnpm run check:supported-syntax-names
+```
+
+Before opening a pull request, run:
+
+```bash
+pnpm run check
+pnpm run check:supported-syntax-names
+```
+
+`pnpm run check` runs formatting, linting, type checking, tests, and package builds.
+
+## Validation Changes
+
+The validator should stay conservative. When behavior is uncertain, prefer skipping a declaration over reporting a diagnostic that may be a false positive.
+
+Add or update tests for:
+
+- the diagnostic that should be reported
+- the compatible case that should stay quiet
+- any conservative skip path introduced by the change
+- CLI behavior when the change affects user-visible output
+
+Spec-driven behavior should include a short comment with the relevant reason or reference. Avoid comments that repeat the code.
+
+## Releases
+
+This project uses Release Please and conventional commits. Use commit or pull request titles such as:
+
+- `feat: support a new validation case`
+- `fix: avoid a false positive for fallback values`
+- `docs: clarify registry-only usage`
+
+See [RELEASING.md](./RELEASING.md) for the release workflow and npm trusted publishing details.

--- a/README.md
+++ b/README.md
@@ -1,248 +1,155 @@
 # CSS Property Type Validator
 
-Standalone tooling for validating CSS custom property registrations declared with `@property` and checking whether registered custom properties are used compatibly through `var()`.
+Validate CSS custom property registrations declared with `@property`, then check whether registered custom properties are used compatibly through `var()`.
 
-## What it does today
+Use it when your design tokens or component styles rely on typed custom properties and you want CI to catch mistakes such as a color token being used for `inline-size`, or a length token being assigned an invalid value.
+
+## What It Does
 
 - Parses CSS with `css-tree`
-- Builds a registry from `@property` rules across multiple input files
-- Validates `syntax` descriptors in those registrations
-- Checks `var()` declaration values against the consuming CSS property, including coordinated multi-`var()` cases
-- Validates simple fallback branches in `var(--token, fallback)` against the consuming property
+- Builds a registry from `@property` rules across input files, registry-only files, and local unconditioned imports
+- Validates `syntax`, `inherits`, and `initial-value` descriptors
+- Checks registered `var()` usages against the consuming CSS property
+- Checks simple `var()` fallback branches against the consuming CSS property
 - Validates authored values assigned directly to registered custom properties
 - Ignores unregistered custom properties
-- Ships a standalone core package and a thin CLI wrapper
+- Skips ambiguous cases conservatively to avoid false positives
 
-## Workspace layout
+## Packages
 
-- `packages/core`: parser, registry builder, and validation engine
-- `packages/cli`: command-line interface for local use and CI
+- [`@schalkneethling/css-property-type-validator-core`](https://www.npmjs.com/package/@schalkneethling/css-property-type-validator-core): validation engine for programmatic use
+- [`@schalkneethling/css-property-type-validator-cli`](https://www.npmjs.com/package/@schalkneethling/css-property-type-validator-cli): command-line wrapper for local development and CI
 
-## Install
+## Try The CLI
 
-### CLI
+```bash
+npx @schalkneethling/css-property-type-validator-cli "src/**/*.css"
+```
+
+Install it globally if you prefer:
 
 ```bash
 npm install --global @schalkneethling/css-property-type-validator-cli
+css-property-type-validator "src/**/*.css"
 ```
 
-Or run it without a global install:
+The CLI exits with:
 
-```bash
-npx @schalkneethling/css-property-type-validator-cli fixtures/imports/main.css
-```
+- `0` when no diagnostics are found
+- `1` when validation diagnostics are found
+- `2` for usage or file-loading failures
 
-### Core library
-
-```bash
-pnpm add @schalkneethling/css-property-type-validator-core
-```
-
-## Published Packages
-
-- Core package: [`@schalkneethling/css-property-type-validator-core`](https://www.npmjs.com/package/@schalkneethling/css-property-type-validator-core)
-- CLI package: [`@schalkneethling/css-property-type-validator-cli`](https://www.npmjs.com/package/@schalkneethling/css-property-type-validator-cli)
-
-## Develop
-
-```bash
-pnpm install
-pnpm run typecheck
-pnpm test
-pnpm run build
-pnpm run check:supported-syntax-names
-```
-
-## CI and Releases
-
-This repository uses GitHub Actions for CI and Release Please for automated releases and npm publishing. See [RELEASING.md](/Users/schalkneethling/dev/opensource/css-property-type-validator/RELEASING.md) for setup details and required secrets.
-
-## Library usage
-
-```ts
-import { validateFiles } from "@schalkneethling/css-property-type-validator-core";
-
-const result = validateFiles([
-  {
-    path: "fixtures/imports/main.css",
-    css: `
-      @property --brand-color {
-        syntax: "<color>";
-        inherits: true;
-        initial-value: transparent;
-      }
-
-      .card {
-        inline-size: var(--brand-color);
-      }
-    `,
-  },
-]);
-
-console.log(result.diagnostics);
-```
-
-## CLI usage
+## CLI Usage
 
 ```bash
 css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 css-property-type-validator "src/tokens/**/*.css" --registry-only
-css-property-type-validator "fixtures/imports/main.css"
 ```
 
-Human output is the default. The CLI exits with:
+Use `--registry` for shared `@property` definitions that should contribute registrations without validating ordinary declarations from those files:
 
-- `0` when no diagnostics are found
-- `1` when validation diagnostics are found
-- `2` for usage or file-loading failures
+```bash
+css-property-type-validator "src/components/**/*.css" --registry "src/tokens/**/*.css"
+```
 
-## Example JSON output
+Use `--registry-only` when you only want to validate `@property` registrations:
+
+```bash
+css-property-type-validator "src/tokens/**/*.css" --registry-only
+```
+
+Registry-only files still report parse errors and invalid `@property` registrations.
+
+## Library Usage
+
+```ts
+import { validateFiles } from "@schalkneethling/css-property-type-validator-core";
+
+const result = validateFiles([
+  {
+    path: "tokens.css",
+    css: `
+      @property --brand-color {
+        syntax: "<color>";
+        inherits: true;
+        initial-value: transparent;
+      }
+    `,
+  },
+  {
+    path: "component.css",
+    css: ".card { inline-size: var(--brand-color); }",
+  },
+]);
+
+console.log(result.diagnostics);
+```
+
+## JSON Output Shape
+
+With `--format json`, the CLI prints the same shape returned by the core package:
 
 ```json
 {
   "diagnostics": [
     {
       "code": "incompatible-var-usage",
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css",
-      "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css",
-        "start": {
-          "offset": 932,
-          "line": 38,
-          "column": 16
-        },
-        "end": {
-          "offset": 950,
-          "line": 38,
-          "column": 34
-        }
-      },
+      "filePath": "/project/component.css",
       "message": "Registered property --brand-color uses syntax \"<color>\" which is incompatible with inline-size at this var() usage.",
       "propertyName": "--brand-color",
       "registeredSyntax": "<color>",
       "expectedProperty": "inline-size",
       "snippet": "inline-size:var(--brand-color)"
-    },
-    {
-      "code": "incompatible-var-usage",
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css",
-      "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css",
-        "start": {
-          "offset": 961,
-          "line": 39,
-          "column": 10
-        },
-        "end": {
-          "offset": 976,
-          "line": 39,
-          "column": 25
-        }
-      },
-      "message": "Registered property --space-md uses syntax \"<length>\" which is incompatible with color at this var() usage.",
-      "propertyName": "--space-md",
-      "registeredSyntax": "<length>",
-      "expectedProperty": "color",
-      "snippet": "color:var(--space-md)"
     }
   ],
   "registry": [
     {
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/nested.css",
-      "inherits": false,
-      "initialValue": "12px",
-      "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/nested.css",
-        "start": {
-          "offset": 0,
-          "line": 1,
-          "column": 1
-        },
-        "end": {
-          "offset": 96,
-          "line": 5,
-          "column": 2
-        }
-      },
-      "name": "--radius-lg",
-      "syntax": "<length>"
-    },
-    {
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/tokens.css",
+      "filePath": "/project/tokens.css",
       "inherits": true,
       "initialValue": "transparent",
-      "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/tokens.css",
-        "start": {
-          "offset": 25,
-          "line": 3,
-          "column": 1
-        },
-        "end": {
-          "offset": 121,
-          "line": 7,
-          "column": 2
-        }
-      },
       "name": "--brand-color",
       "syntax": "<color>"
-    },
-    {
-      "filePath": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/tokens.css",
-      "inherits": false,
-      "initialValue": "16px",
-      "loc": {
-        "source": "/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/registry/tokens.css",
-        "start": {
-          "offset": 123,
-          "line": 9,
-          "column": 1
-        },
-        "end": {
-          "offset": 211,
-          "line": 13,
-          "column": 2
-        }
-      },
-      "name": "--space-md",
-      "syntax": "<length>"
     }
   ],
   "skippedDeclarations": 0,
-  "validatedDeclarations": 30
+  "validatedDeclarations": 1
 }
 ```
 
-This example is truncated for readability. A full run against [fixtures/imports/main.css](/Users/schalkneethling/dev/opensource/css-property-type-validator/fixtures/imports/main.css) also includes invalid `@property` registrations from imported registry files, authored custom property assignment diagnostics, and more specific multi-`var()` messages when the validator can narrow the likely culprit.
+Locations are included when available.
 
-## Current validation model
+## Current Validation Model
 
-The validator assembles one registry from the full set of input files, then checks each stylesheet against that combined registry.
+The validator assembles one registry from the full set of validation inputs, registry-only inputs, and resolved local imports. It then checks each validation input against that combined registry.
 
-When shared registrations live outside the files you want to validate, the CLI can add them as registry-only sources:
+When a resolver is available, the core follows local unconditioned `@import` rules while assembling the registry. The CLI provides a resolver for relative and root-relative local CSS imports. Remote imports and conditioned imports are intentionally out of scope for now.
 
-```bash
-css-property-type-validator "src/components/**/*.css" --registry "src/tokens/**/*.css"
-```
+Compatibility checks are conservative:
 
-Registry-only files contribute `@property` registrations and any registration/parse diagnostics, but their own normal declarations are not validated unless you also pass them as main inputs.
-
-When you want to validate registrations on their own, use the explicit registration-only mode:
-
-```bash
-css-property-type-validator "src/tokens/**/*.css" --registry-only
-```
-
-In `--registry-only` mode, the positional patterns are treated as registration sources rather than normal declaration-validation targets.
-
-When a resolver is available, the validator also follows local unconditioned `@import` rules while assembling the registry. That includes relative imports and root-relative imports in the CLI. Remote imports and conditioned imports remain intentionally out of scope for now.
-
-For this first cut, compatibility checks are intentionally conservative:
-
-- whitespace-toggle and similarly ambiguous custom property assignment patterns are skipped for now
-- conditioned and remote `@import` traversal are not implemented yet
+- whitespace-toggle and similarly ambiguous custom property assignment patterns are skipped
+- nested fallback chains are skipped until fallback reachability can be modeled safely
+- universal-syntax registrations are skipped for compatibility checks because their computed value can still be valid
 - config-file based registry discovery is not implemented yet
 
-That keeps false positives down while the standalone core takes shape.
+## Develop
+
+```bash
+pnpm install
+pnpm run format:check
+pnpm run lint
+pnpm run typecheck
+pnpm test
+pnpm run build
+pnpm run check:supported-syntax-names
+```
+
+For the full local gate:
+
+```bash
+pnpm run check
+pnpm run check:supported-syntax-names
+```
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md) for contributor guidance and [RELEASING.md](./RELEASING.md) for release details.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,25 +1,27 @@
 # Roadmap
 
-## Near term
+## Current State
 
-- Prioritize support for declarations containing multiple `var()` usages in a single value.
-  This is likely the biggest gap for real-world design-token usage because shorthand and composite values routinely combine multiple custom properties.
-- Validate authored values assigned directly to registered custom properties.
-  Example: flag `--brand-color: 10px` when `--brand-color` is registered as `"<color>"`.
+- Validates `@property` syntax, `inherits`, and `initial-value` descriptors.
+- Validates authored values assigned directly to registered custom properties.
+- Supports declarations with multiple registered `var()` usages in one value.
+- Validates simple fallback branches in ordinary consuming declarations.
+- Assembles registrations from validation inputs, registry-only inputs, and local unconditioned imports.
+- Maintains a frozen list of supported syntax component names and checks it against the published spec.
+
+## Near Term
+
 - Handle custom property patterns that rely on whitespace or fallback toggles.
   Example: account for the "space toggle" / `--foo: ;` pattern when validating assignments and `var(--foo, fallback)` usage.
 - Improve syntax compatibility checking beyond representative sample substitution where practical.
   Goal: reduce heuristic gaps for more complex syntax descriptors and consuming properties.
 - Expand diagnostics with clearer remediation guidance.
-  Example: include more context about the registered syntax and the property that rejected it.
-- Document and maintain a `css-tree` update strategy.
-  Goal: track parser/lexer coverage as CSS evolves and reduce false positives or false negatives caused by stale syntax/property data.
+  Example: include more context about the registered syntax, the consuming property, and likely fixes.
+- Add config-file based registry discovery.
+  Goal: make repeated CLI usage easier for projects with shared token registries.
 
 ## Later
 
-- Support validation across imported stylesheets.
-  Goal: allow registry assembly from `@import` graphs instead of only explicit file inputs.
-  A simpler first step could be a CLI option that accepts one or more registry files explicitly.
 - Add a Stylelint adapter on top of the standalone core.
 - Explore an ESLint CSS adapter once the standalone core behavior is stable.
 - Explore how typed CSS mixins and mixin-like patterns could strengthen the project's long-term value proposition.

--- a/package.json
+++ b/package.json
@@ -17,6 +17,10 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r --if-present run build",
+    "check": "vp check && pnpm run typecheck && pnpm test && pnpm run build",
+    "format": "vp check --fix",
+    "format:check": "vp check --no-lint",
+    "lint": "vp check --no-fmt",
     "test": "vp test run",
     "typecheck": "tsc -b tsconfig.json",
     "check:supported-syntax-names": "node scripts/check-supported-syntax-names.mjs",

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -2,37 +2,32 @@
 
 ## [0.4.0](https://github.com/schalkneethling/css-property-type-validator/compare/cli-v0.3.0...cli-v0.4.0) (2026-04-22)
 
-
 ### Features
 
-* **cli:** add explicit registration-only mode for [@property](https://github.com/property) validation ([a38ac90](https://github.com/schalkneethling/css-property-type-validator/commit/a38ac90b6faaf93d5a065bc301f7ede19768f52b))
-* **cli:** add registration-only mode ([aec5594](https://github.com/schalkneethling/css-property-type-validator/commit/aec5594d3a2aa18e5eba12981ea29c3f7a8069f5))
-
+- **cli:** add explicit registration-only mode for [@property](https://github.com/property) validation ([a38ac90](https://github.com/schalkneethling/css-property-type-validator/commit/a38ac90b6faaf93d5a065bc301f7ede19768f52b))
+- **cli:** add registration-only mode ([aec5594](https://github.com/schalkneethling/css-property-type-validator/commit/aec5594d3a2aa18e5eba12981ea29c3f7a8069f5))
 
 ### Bug Fixes
 
-* **cli:** reuse default missing-input error ([fe63b97](https://github.com/schalkneethling/css-property-type-validator/commit/fe63b97c989b0bd0e5c2c2c0dfa0a0670c977132))
+- **cli:** reuse default missing-input error ([fe63b97](https://github.com/schalkneethling/css-property-type-validator/commit/fe63b97c989b0bd0e5c2c2c0dfa0a0670c977132))
 
 ## [0.3.0](https://github.com/schalkneethling/css-property-type-validator/compare/cli-v0.2.0...cli-v0.3.0) (2026-04-22)
 
-
 ### Features
 
-* Add local import traversal for registry assembly ([bf853e7](https://github.com/schalkneethling/css-property-type-validator/commit/bf853e738c2146ce2ba0ca77ca01afa77a0183f0))
+- Add local import traversal for registry assembly ([bf853e7](https://github.com/schalkneethling/css-property-type-validator/commit/bf853e738c2146ce2ba0ca77ca01afa77a0183f0))
 
 ## [0.2.0](https://github.com/schalkneethling/css-property-type-validator/compare/cli-v0.1.1...cli-v0.2.0) (2026-04-15)
 
-
 ### Features
 
-* Add registry input support to validator ([c4a1fb8](https://github.com/schalkneethling/css-property-type-validator/commit/c4a1fb806933488c857a27b67ea29daaca790b2e))
-* validate authored registered custom property values ([36a8fd9](https://github.com/schalkneethling/css-property-type-validator/commit/36a8fd9cf0c2d58065fd149bbfaf8c70710b242f))
-* validate authored registered custom property values ([35b06e6](https://github.com/schalkneethling/css-property-type-validator/commit/35b06e6149939c7f693edde9302a8f8e567980bb))
+- Add registry input support to validator ([c4a1fb8](https://github.com/schalkneethling/css-property-type-validator/commit/c4a1fb806933488c857a27b67ea29daaca790b2e))
+- validate authored registered custom property values ([36a8fd9](https://github.com/schalkneethling/css-property-type-validator/commit/36a8fd9cf0c2d58065fd149bbfaf8c70710b242f))
+- validate authored registered custom property values ([35b06e6](https://github.com/schalkneethling/css-property-type-validator/commit/35b06e6149939c7f693edde9302a8f8e567980bb))
 
 ## [0.1.1](https://github.com/schalkneethling/css-property-type-validator/compare/cli-v0.1.0...cli-v0.1.1) (2026-04-02)
 
-
 ### Bug Fixes
 
-* include package readmes in published packages ([50ac723](https://github.com/schalkneethling/css-property-type-validator/commit/50ac7236b861b65d5ad1ef188a2738d6f01305cb))
-* include package readmes in published packages ([2ca19d0](https://github.com/schalkneethling/css-property-type-validator/commit/2ca19d0b738013bc1755055056eea693e3cf337c))
+- include package readmes in published packages ([50ac723](https://github.com/schalkneethling/css-property-type-validator/commit/50ac7236b861b65d5ad1ef188a2738d6f01305cb))
+- include package readmes in published packages ([2ca19d0](https://github.com/schalkneethling/css-property-type-validator/commit/2ca19d0b738013bc1755055056eea693e3cf337c))

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,8 +1,8 @@
 # @schalkneethling/css-property-type-validator-cli
 
-CLI for CSS Property Type Validator.
+Command-line interface for CSS Property Type Validator.
 
-This package validates CSS `@property` registrations, checks whether registered custom properties are used compatibly through `var()`, and validates authored assignments to registered custom properties.
+Use it locally or in CI to validate CSS `@property` registrations, registered `var()` usage, simple fallback branches, and authored assignments to registered custom properties.
 
 ## Install
 
@@ -10,7 +10,7 @@ This package validates CSS `@property` registrations, checks whether registered 
 npm install --global @schalkneethling/css-property-type-validator-cli
 ```
 
-Or run it with `npx`:
+Or run it without installing:
 
 ```bash
 npx @schalkneethling/css-property-type-validator-cli "src/**/*.css"
@@ -23,10 +23,9 @@ css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 css-property-type-validator "src/tokens/**/*.css" --registry-only
-css-property-type-validator "fixtures/imports/main.css"
 ```
 
-Use `--registry` multiple times to include shared `@property` definitions without validating the rest of those files:
+Use `--registry` multiple times to include shared registration sources:
 
 ```bash
 css-property-type-validator "src/**/*.css" \
@@ -34,17 +33,9 @@ css-property-type-validator "src/**/*.css" \
   --registry "src/brand/**/*.css"
 ```
 
-Registry-only files still report parse errors and invalid `@property` registrations. The CLI also follows local unconditioned `@import` rules automatically while assembling the registry, including relative and root-relative imports. Remote and conditioned imports are still out of scope for now.
+The CLI follows local unconditioned `@import` rules while assembling the registry, including relative and root-relative imports. Remote and conditioned imports are skipped.
 
-Use `--registry-only` when you want to validate `@property` rules without also validating ordinary declarations from those files:
-
-```bash
-css-property-type-validator "src/tokens/**/*.css" --registry-only
-```
-
-In `--registry-only` mode, the positional patterns become registration sources instead of normal validation targets. You can still add extra shared registry inputs with `--registry` when needed.
-
-## Exit codes
+## Exit Codes
 
 - `0` no diagnostics found
 - `1` validation diagnostics found

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,14 +3,23 @@
   "version": "0.4.0",
   "description": "CLI for CSS custom property type validator.",
   "keywords": [
+    "cli",
     "css",
     "custom-properties",
     "property",
-    "validator",
-    "cli"
+    "validator"
   ],
+  "homepage": "https://github.com/schalkneethling/css-property-type-validator#readme",
+  "bugs": {
+    "url": "https://github.com/schalkneethling/css-property-type-validator/issues"
+  },
   "license": "MIT",
   "author": "Schalk Neethling",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/schalkneethling/css-property-type-validator.git",
+    "directory": "packages/cli"
+  },
   "bin": {
     "css-property-type-validator": "./dist/cli.js"
   },
@@ -19,15 +28,6 @@
     "README.md"
   ],
   "type": "module",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/schalkneethling/css-property-type-validator.git",
-    "directory": "packages/cli"
-  },
-  "homepage": "https://github.com/schalkneethling/css-property-type-validator#readme",
-  "bugs": {
-    "url": "https://github.com/schalkneethling/css-property-type-validator/issues"
-  },
   "publishConfig": {
     "access": "public"
   },

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -98,58 +98,61 @@ async function main(): Promise<void> {
         patterns: string[],
         options: { format: OutputFormat; registry: string[]; registryOnly: boolean },
       ) => {
-      const format = resolveOutputFormat(options.format);
+        const format = resolveOutputFormat(options.format);
 
-      if (options.registryOnly) {
-        if (patterns.length === 0) {
+        if (options.registryOnly) {
+          if (patterns.length === 0) {
+            process.stderr.write(
+              "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
+            );
+            process.exitCode = 2;
+            return;
+          }
+
+          const registryInputs = await loadInputs(patterns);
+
+          if (registryInputs.length === 0) {
+            process.stderr.write(
+              "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
+            );
+            process.exitCode = 2;
+            return;
+          }
+
+          const additionalRegistryInputs = await loadRegistryInputs(
+            options.registry,
+            registryInputs,
+          );
+          const result = validateFiles([], {
+            registryInputs: [...registryInputs, ...additionalRegistryInputs],
+            resolveImport: createImportResolver(process.cwd()),
+          });
+          const output = formatValidationResult(result, format);
+
+          process.stdout.write(`${output}\n`);
+          process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
+          return;
+        }
+
+        const inputs = await loadInputs(patterns);
+
+        if (inputs.length === 0) {
           process.stderr.write(
-            "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
+            "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.\n",
           );
           process.exitCode = 2;
           return;
         }
 
-        const registryInputs = await loadInputs(patterns);
-
-        if (registryInputs.length === 0) {
-          process.stderr.write(
-            "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
-          );
-          process.exitCode = 2;
-          return;
-        }
-
-        const additionalRegistryInputs = await loadRegistryInputs(options.registry, registryInputs);
-        const result = validateFiles([], {
-          registryInputs: [...registryInputs, ...additionalRegistryInputs],
+        const registryInputs = await loadRegistryInputs(options.registry, inputs);
+        const result = validateFiles(inputs, {
+          registryInputs,
           resolveImport: createImportResolver(process.cwd()),
         });
         const output = formatValidationResult(result, format);
 
         process.stdout.write(`${output}\n`);
         process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
-        return;
-      }
-
-      const inputs = await loadInputs(patterns);
-
-      if (inputs.length === 0) {
-        process.stderr.write(
-          "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.\n",
-        );
-        process.exitCode = 2;
-        return;
-      }
-
-      const registryInputs = await loadRegistryInputs(options.registry, inputs);
-      const result = validateFiles(inputs, {
-        registryInputs,
-        resolveImport: createImportResolver(process.cwd()),
-      });
-      const output = formatValidationResult(result, format);
-
-      process.stdout.write(`${output}\n`);
-      process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
       },
     );
 

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -6,9 +6,7 @@
     "ignoreDeprecations": "6.0",
     "baseUrl": ".",
     "paths": {
-      "@schalkneethling/css-property-type-validator-core": [
-        "../core/src/index.ts"
-      ]
+      "@schalkneethling/css-property-type-validator-core": ["../core/src/index.ts"]
     }
   },
   "references": [

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -2,60 +2,52 @@
 
 ## [0.7.0](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.6.0...core-v0.7.0) (2026-04-22)
 
-
 ### Features
 
-* **core:** validate simple var() fallback branches ([d8f1de6](https://github.com/schalkneethling/css-property-type-validator/commit/d8f1de62b0184c236e844927c8e0ee50b2641c9a))
-* **core:** validate simple var() fallback branches ([6db9510](https://github.com/schalkneethling/css-property-type-validator/commit/6db95107a58a8863830bd6bbfca8129f32691c6c))
+- **core:** validate simple var() fallback branches ([d8f1de6](https://github.com/schalkneethling/css-property-type-validator/commit/d8f1de62b0184c236e844927c8e0ee50b2641c9a))
+- **core:** validate simple var() fallback branches ([6db9510](https://github.com/schalkneethling/css-property-type-validator/commit/6db95107a58a8863830bd6bbfca8129f32691c6c))
 
 ## [0.6.0](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.5.0...core-v0.6.0) (2026-04-22)
 
-
 ### Features
 
-* **cli:** add explicit registration-only mode for [@property](https://github.com/property) validation ([a38ac90](https://github.com/schalkneethling/css-property-type-validator/commit/a38ac90b6faaf93d5a065bc301f7ede19768f52b))
-* **cli:** add registration-only mode ([aec5594](https://github.com/schalkneethling/css-property-type-validator/commit/aec5594d3a2aa18e5eba12981ea29c3f7a8069f5))
-
+- **cli:** add explicit registration-only mode for [@property](https://github.com/property) validation ([a38ac90](https://github.com/schalkneethling/css-property-type-validator/commit/a38ac90b6faaf93d5a065bc301f7ede19768f52b))
+- **cli:** add registration-only mode ([aec5594](https://github.com/schalkneethling/css-property-type-validator/commit/aec5594d3a2aa18e5eba12981ea29c3f7a8069f5))
 
 ### Bug Fixes
 
-* **cli:** reuse default missing-input error ([fe63b97](https://github.com/schalkneethling/css-property-type-validator/commit/fe63b97c989b0bd0e5c2c2c0dfa0a0670c977132))
+- **cli:** reuse default missing-input error ([fe63b97](https://github.com/schalkneethling/css-property-type-validator/commit/fe63b97c989b0bd0e5c2c2c0dfa0a0670c977132))
 
 ## [0.5.0](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.4.0...core-v0.5.0) (2026-04-22)
 
-
 ### Features
 
-* Add local import traversal for registry assembly ([bf853e7](https://github.com/schalkneethling/css-property-type-validator/commit/bf853e738c2146ce2ba0ca77ca01afa77a0183f0))
+- Add local import traversal for registry assembly ([bf853e7](https://github.com/schalkneethling/css-property-type-validator/commit/bf853e738c2146ce2ba0ca77ca01afa77a0183f0))
 
 ## [0.4.0](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.3.0...core-v0.4.0) (2026-04-16)
 
-
 ### Features
 
-* Align [@property](https://github.com/property) registration validation with spec ([7595823](https://github.com/schalkneethling/css-property-type-validator/commit/759582387a5d4cf2f012edcf882e95d9a4d2e238))
+- Align [@property](https://github.com/property) registration validation with spec ([7595823](https://github.com/schalkneethling/css-property-type-validator/commit/759582387a5d4cf2f012edcf882e95d9a4d2e238))
 
 ## [0.3.0](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.2.0...core-v0.3.0) (2026-04-15)
 
-
 ### Features
 
-* Add registry input support to validator ([c4a1fb8](https://github.com/schalkneethling/css-property-type-validator/commit/c4a1fb806933488c857a27b67ea29daaca790b2e))
-* validate authored registered custom property values ([36a8fd9](https://github.com/schalkneethling/css-property-type-validator/commit/36a8fd9cf0c2d58065fd149bbfaf8c70710b242f))
-* validate authored registered custom property values ([35b06e6](https://github.com/schalkneethling/css-property-type-validator/commit/35b06e6149939c7f693edde9302a8f8e567980bb))
+- Add registry input support to validator ([c4a1fb8](https://github.com/schalkneethling/css-property-type-validator/commit/c4a1fb806933488c857a27b67ea29daaca790b2e))
+- validate authored registered custom property values ([36a8fd9](https://github.com/schalkneethling/css-property-type-validator/commit/36a8fd9cf0c2d58065fd149bbfaf8c70710b242f))
+- validate authored registered custom property values ([35b06e6](https://github.com/schalkneethling/css-property-type-validator/commit/35b06e6149939c7f693edde9302a8f8e567980bb))
 
 ## [0.2.0](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.1.1...core-v0.2.0) (2026-04-02)
 
-
 ### Features
 
-* support declarations with multiple var() usages ([03d230e](https://github.com/schalkneethling/css-property-type-validator/commit/03d230e177e8790d60c4115e4294b83722b5eef2))
-* support declarations with multiple var() usages ([aa8f1db](https://github.com/schalkneethling/css-property-type-validator/commit/aa8f1db6e6321f687335a127ff8289a3c9685c27))
+- support declarations with multiple var() usages ([03d230e](https://github.com/schalkneethling/css-property-type-validator/commit/03d230e177e8790d60c4115e4294b83722b5eef2))
+- support declarations with multiple var() usages ([aa8f1db](https://github.com/schalkneethling/css-property-type-validator/commit/aa8f1db6e6321f687335a127ff8289a3c9685c27))
 
 ## [0.1.1](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.1.0...core-v0.1.1) (2026-04-02)
 
-
 ### Bug Fixes
 
-* include package readmes in published packages ([50ac723](https://github.com/schalkneethling/css-property-type-validator/commit/50ac7236b861b65d5ad1ef188a2738d6f01305cb))
-* include package readmes in published packages ([2ca19d0](https://github.com/schalkneethling/css-property-type-validator/commit/2ca19d0b738013bc1755055056eea693e3cf337c))
+- include package readmes in published packages ([50ac723](https://github.com/schalkneethling/css-property-type-validator/commit/50ac7236b861b65d5ad1ef188a2738d6f01305cb))
+- include package readmes in published packages ([2ca19d0](https://github.com/schalkneethling/css-property-type-validator/commit/2ca19d0b738013bc1755055056eea693e3cf337c))

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Core validation engine for CSS Property Type Validator.
 
-This package reads CSS `@property` registrations, builds a registry of typed custom properties, validates compatible `var()` usage against consuming CSS properties, validates simple `var()` fallback branches against consuming CSS properties, and checks authored assignments to registered custom properties.
+It reads CSS `@property` registrations, builds a registry of typed custom properties, validates registration descriptors, checks compatible `var()` usage against consuming CSS properties, validates simple fallback branches, and checks authored assignments to registered custom properties.
 
 ## Install
 
@@ -18,23 +18,13 @@ import { validateFiles } from "@schalkneethling/css-property-type-validator-core
 const result = validateFiles(
   [
     {
-      path: "fixtures/imports/main.css",
-      css: `
-        @import "./tokens.css";
-
-        .card {
-          color: var(--brand-color);
-        }
-      `,
+      path: "component.css",
+      css: ".card { color: var(--brand-color); }",
     },
   ],
   {
-    resolveImport: (specifier, fromPath) => {
-      if (specifier !== "./tokens.css" || fromPath !== "fixtures/imports/main.css") {
-        return null;
-      }
-
-      return {
+    registryInputs: [
+      {
         path: "tokens.css",
         css: `
           @property --brand-color {
@@ -43,24 +33,30 @@ const result = validateFiles(
             initial-value: transparent;
           }
         `,
-      };
-    },
+      },
+    ],
   },
 );
 
 console.log(result.diagnostics);
 ```
 
+Provide `resolveImport` when registry assembly should follow local unconditioned imports:
+
+```ts
+const result = validateFiles(inputs, {
+  resolveImport: (specifier, fromPath) => {
+    // Return { path, css } for local CSS imports, or null when unresolved.
+    return null;
+  },
+});
+```
+
 ## Notes
 
-- Validates `@property` syntax descriptors
-- Builds a registry across provided input files
-- Can extend that registry with optional `registryInputs`
-- Can follow local unconditioned `@import` rules when `resolveImport` is provided
-- Validates single-`var()` declaration usages
-- Validates authored values assigned to registered custom properties
-- Skips whitespace-toggle and similarly ambiguous custom property assignment patterns for now
-- Skips conditioned and remote `@import` traversal for now
-- Ignores unregistered custom properties
+- `registryInputs` contribute registrations and registration diagnostics without validating ordinary declarations from those files.
+- Unregistered custom properties are ignored.
+- Ambiguous cases are skipped conservatively to avoid false positives.
+- Remote and conditioned imports are out of scope unless a future validation model can handle them safely.
 
 Repository: [schalkneethling/css-property-type-validator](https://github.com/schalkneethling/css-property-type-validator)

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -5,12 +5,21 @@
   "keywords": [
     "css",
     "custom-properties",
+    "design-tokens",
     "property",
-    "validator",
-    "design-tokens"
+    "validator"
   ],
+  "homepage": "https://github.com/schalkneethling/css-property-type-validator#readme",
+  "bugs": {
+    "url": "https://github.com/schalkneethling/css-property-type-validator/issues"
+  },
   "license": "MIT",
   "author": "Schalk Neethling",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/schalkneethling/css-property-type-validator.git",
+    "directory": "packages/core"
+  },
   "files": [
     "dist",
     "README.md"
@@ -18,15 +27,6 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/schalkneethling/css-property-type-validator.git",
-    "directory": "packages/core"
-  },
-  "homepage": "https://github.com/schalkneethling/css-property-type-validator#readme",
-  "bugs": {
-    "url": "https://github.com/schalkneethling/css-property-type-validator/issues"
-  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -178,8 +178,7 @@ function getComputationalIndependenceFailureReason(value: unknown): string | nul
         const unit = String(node.unit ?? "").toLowerCase();
 
         if (!COMPUTATION_INDEPENDENT_DIMENSION_UNITS.includes(unit)) {
-          failure =
-            `uses the relative or context-dependent unit "${node.unit}", which makes the registration invalid because initial-value must be computationally independent`;
+          failure = `uses the relative or context-dependent unit "${node.unit}", which makes the registration invalid because initial-value must be computationally independent`;
         }
 
         return;
@@ -226,9 +225,9 @@ function validateInitialValueAgainstSyntax(
 
 function getStringDescriptor(declaration: CssDeclarationNode | undefined): string | undefined {
   const valueChildren = declaration?.value?.children;
-  const firstNode = (valueChildren
+  const firstNode = valueChildren
     ? (Array.from(valueChildren)[0] as CssStringNode | undefined)
-    : undefined);
+    : undefined;
 
   if (firstNode?.type === "String") {
     return firstNode.value;
@@ -278,9 +277,7 @@ function processPropertyRule(
   diagnostics: ValidationDiagnostic[],
   registry: Map<string, RegisteredProperty>,
 ): void {
-  const propertyName = (
-    Array.from(node.prelude?.children ?? []) as CssPropertyNameNode[]
-  )[0]?.name;
+  const propertyName = (Array.from(node.prelude?.children ?? []) as CssPropertyNameNode[])[0]?.name;
 
   if (!propertyName) {
     diagnostics.push({

--- a/packages/core/src/supported-syntax.ts
+++ b/packages/core/src/supported-syntax.ts
@@ -20,7 +20,14 @@ export const SUPPORTED_SYNTAX_COMPONENT_NAMES = Object.freeze([
   "<transform-list>",
 ] as readonly string[]);
 
-function validateNode(node: any): string | null {
+interface DefinitionSyntaxNode {
+  name?: string;
+  term?: DefinitionSyntaxNode;
+  terms?: DefinitionSyntaxNode[];
+  type?: string;
+}
+
+function validateNode(node: DefinitionSyntaxNode | null | undefined): string | null {
   if (!node) {
     return null;
   }
@@ -53,6 +60,6 @@ function validateNode(node: any): string | null {
   }
 }
 
-export function getFirstUnsupportedSyntaxComponentName(syntaxAst: any): string | null {
-  return validateNode(syntaxAst);
+export function getFirstUnsupportedSyntaxComponentName(syntaxAst: unknown): string | null {
+  return validateNode(syntaxAst as DefinitionSyntaxNode);
 }

--- a/packages/core/src/syntax-samples.ts
+++ b/packages/core/src/syntax-samples.ts
@@ -26,6 +26,21 @@ const SIMPLE_TYPE_SAMPLES: Record<string, string[]> = {
   url: ['url("https://example.com/example.png")'],
 };
 
+interface DefinitionSyntaxNode {
+  combinator?: string;
+  comma?: boolean;
+  min?: number;
+  name?: string;
+  term?: DefinitionSyntaxNode;
+  terms?: DefinitionSyntaxNode[];
+  type?: string;
+  value?: string;
+}
+
+interface DefinitionSyntaxParser {
+  parse: (syntax: string) => unknown;
+}
+
 function dedupe(values: string[]): string[] {
   return [...new Set(values)];
 }
@@ -48,7 +63,7 @@ function fromFunctionName(name: string): string[] {
   return [];
 }
 
-function fromNode(node: any): string[] {
+function fromNode(node: DefinitionSyntaxNode | null | undefined): string[] {
   if (!node) {
     return [];
   }
@@ -81,16 +96,16 @@ function fromNode(node: any): string[] {
     }
 
     case "Keyword":
-      return [node.name];
+      return node.name ? [node.name] : [];
 
     case "Type":
-      return SIMPLE_TYPE_SAMPLES[node.name] ?? fromFunctionName(node.name);
+      return node.name ? (SIMPLE_TYPE_SAMPLES[node.name] ?? fromFunctionName(node.name)) : [];
 
     case "Property":
-      return SIMPLE_TYPE_SAMPLES[node.name] ?? [];
+      return node.name ? (SIMPLE_TYPE_SAMPLES[node.name] ?? []) : [];
 
     case "Function":
-      return fromFunctionName(node.name);
+      return node.name ? fromFunctionName(node.name) : [];
 
     case "String":
       return [`"${node.value ?? "value"}"`];
@@ -100,11 +115,11 @@ function fromNode(node: any): string[] {
   }
 }
 
-export function buildRepresentativeSamples(syntax: string, definitionSyntax: any): string[] {
+export function buildRepresentativeSamples(syntax: string, definitionSyntax: unknown): string[] {
   if (syntax === "*") {
     return ["0"];
   }
 
-  const syntaxAst = definitionSyntax.parse(syntax);
-  return dedupe(fromNode(syntaxAst)).slice(0, 8);
+  const syntaxAst = (definitionSyntax as DefinitionSyntaxParser).parse(syntax);
+  return dedupe(fromNode(syntaxAst as DefinitionSyntaxNode)).slice(0, 8);
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -15,10 +15,7 @@ export interface ValidationInput {
   css: string;
 }
 
-export type ResolveImport = (
-  specifier: string,
-  fromPath: string,
-) => ValidationInput | null;
+export type ResolveImport = (specifier: string, fromPath: string) => ValidationInput | null;
 
 export interface RegisteredProperty {
   filePath: string;

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -2,6 +2,12 @@ import * as cssTree from "css-tree";
 
 import { buildRepresentativeSamples } from "./syntax-samples.js";
 import { collectRegistry } from "./registry.js";
+import {
+  canDeclarationMatchWithoutOccurrence,
+  canDeclarationMatchWithOccurrenceReplacement,
+  collectVarOccurrences,
+  isCompatibleWithSubstitutions,
+} from "./var-substitution.js";
 
 import type {
   RegisteredProperty,
@@ -10,30 +16,21 @@ import type {
   ValidationInput,
   ValidationResult,
 } from "./types.js";
+import type {
+  CssNodeWithLoc,
+  CssValueAst,
+  Matcher,
+  ReplacementCheckContext,
+  SubstitutionOption,
+  VarFunctionNode,
+  VarOccurrence,
+} from "./var-substitution.js";
 
 export interface ValidateFilesOptions {
   registryInputs?: ValidationInput[];
   resolveImport?: ResolveImport;
 }
 
-type CssValueAst = any;
-type CssNodeWithLoc = { loc?: any; name?: string; type?: string; value?: string };
-type CssNodeList<TNode> = { first?: TNode; toArray?: () => TNode[] };
-type VarFunctionNode = {
-  children?: CssNodeList<CssNodeWithLoc> | CssNodeWithLoc[];
-  loc?: any;
-  name?: string;
-};
-type VarOccurrence = { end: number; start: number; varNode: VarFunctionNode };
-type SubstitutionOption = { index: number; samples: string[]; varNode: VarFunctionNode };
-type ActiveSubstitution = { sample: string; varNode: VarFunctionNode };
-type Matcher = (candidateValue: CssValueAst) => boolean;
-type ReplacementCheckContext = {
-  matcher: Matcher;
-  occurrences: VarOccurrence[];
-  substitutionOptions: SubstitutionOption[];
-  valueSource: string;
-};
 type FallbackEntry = {
   fallbackSource: string;
   index: number;
@@ -41,14 +38,30 @@ type FallbackEntry = {
   varNode: VarFunctionNode;
 };
 
-function toLocation(loc: any): ValidationDiagnostic["loc"] {
-  return loc
-    ? {
-        source: loc.source,
-        start: { ...loc.start },
-        end: { ...loc.end },
-      }
-    : null;
+interface CssDeclarationNode {
+  loc?: unknown;
+  property: string;
+  value: CssValueAst & { loc?: unknown };
+}
+
+interface CssWalkNode {
+  type?: string;
+}
+
+type CssLocation = NonNullable<ValidationDiagnostic["loc"]>;
+
+function toLocation(loc: unknown): ValidationDiagnostic["loc"] {
+  if (!loc) {
+    return null;
+  }
+
+  const typedLoc = loc as CssLocation;
+
+  return {
+    source: typedLoc.source,
+    start: { ...typedLoc.start },
+    end: { ...typedLoc.end },
+  };
 }
 
 function registryMap(registry: RegisteredProperty[]): Map<string, RegisteredProperty> {
@@ -59,12 +72,12 @@ function isCustomPropertyName(propertyName: string): boolean {
   return propertyName.startsWith("--");
 }
 
-function collectVarFunctions(value: any): any[] {
-  const functions: any[] = [];
+function collectVarFunctions(value: CssValueAst): VarFunctionNode[] {
+  const functions: VarFunctionNode[] = [];
 
   cssTree.walk(value, {
     visit: "Function",
-    enter(node: any) {
+    enter(node: VarFunctionNode) {
       if (node.name === "var") {
         functions.push(node);
       }
@@ -74,7 +87,7 @@ function collectVarFunctions(value: any): any[] {
   return functions;
 }
 
-function getDeclarationValueForValidation(declaration: any): any | null {
+function getDeclarationValueForValidation(declaration: CssDeclarationNode): CssValueAst | null {
   if (isCustomPropertyName(declaration.property)) {
     return parseValue(cssTree.generate(declaration.value));
   }
@@ -116,13 +129,13 @@ function getVarFallbackSource(node: VarFunctionNode): string | null {
 
 function parseValue(value: string): CssValueAst | null {
   try {
-    return cssTree.parse(value, { context: "value" });
+    return cssTree.parse(value, { context: "value" }) as CssValueAst;
   } catch {
     return null;
   }
 }
 
-function matchRegisteredSyntax(registration: RegisteredProperty, value: any): boolean {
+function matchRegisteredSyntax(registration: RegisteredProperty, value: CssValueAst): boolean {
   if (registration.syntax === "*") {
     return true;
   }
@@ -131,81 +144,9 @@ function matchRegisteredSyntax(registration: RegisteredProperty, value: any): bo
   return Boolean(match?.matched);
 }
 
-function collectVarOccurrences(
-  valueSource: string,
-  varNodes: VarFunctionNode[],
-): VarOccurrence[] | null {
-  const occurrences = [];
-  let searchStart = 0;
-
-  for (const varNode of varNodes) {
-    const replacementTarget = cssTree.generate(varNode);
-    const start = valueSource.indexOf(replacementTarget, searchStart);
-
-    if (start === -1) {
-      return null;
-    }
-
-    const end = start + replacementTarget.length;
-
-    occurrences.push({ start, end, varNode });
-    searchStart = end;
-  }
-
-  return occurrences;
-}
-
-function renderValueWithReplacements(
-  valueSource: string,
-  occurrences: VarOccurrence[],
-  replacements: Array<string | null>,
-): string {
-  let rendered = "";
-  let cursor = 0;
-
-  for (const [index, occurrence] of occurrences.entries()) {
-    rendered += valueSource.slice(cursor, occurrence.start);
-    rendered += replacements[index] ?? "";
-    cursor = occurrence.end;
-  }
-
-  rendered += valueSource.slice(cursor);
-
-  return rendered.trim();
-}
-
-function valueMatchesRenderedSource(
-  renderedSource: string,
-  matcher: Matcher,
-): boolean {
-  const replacedAst = parseValue(renderedSource);
-
-  if (!replacedAst) {
-    return false;
-  }
-
-  return matcher(replacedAst);
-}
-
-function valueMatchesSamples(
-  valueSource: string,
-  occurrences: VarOccurrence[],
-  substitutions: ActiveSubstitution[],
-  matcher: Matcher,
-): boolean {
-  const replacementMap = new Map(substitutions.map((substitution) => [substitution.varNode, substitution.sample]));
-  const renderedSource = renderValueWithReplacements(
-    valueSource,
-    occurrences,
-    occurrences.map((occurrence) => replacementMap.get(occurrence.varNode) ?? null),
-  );
-
-  return valueMatchesRenderedSource(renderedSource, matcher);
-}
-
 function toVarDiagnostic(
   filePath: string,
-  declaration: any,
+  declaration: CssDeclarationNode,
   registrations: RegisteredProperty[],
   varNodes: VarFunctionNode[],
 ): ValidationDiagnostic {
@@ -241,7 +182,7 @@ function toVarDiagnostic(
 
 function toPossibleVarDiagnostic(
   filePath: string,
-  declaration: any,
+  declaration: CssDeclarationNode,
   registrations: RegisteredProperty[],
 ): ValidationDiagnostic {
   const uniqueNames = [...new Set(registrations.map((registration) => registration.name))];
@@ -262,7 +203,7 @@ function toPossibleVarDiagnostic(
 
 function toAssignmentDiagnostic(
   filePath: string,
-  declaration: any,
+  declaration: CssDeclarationNode,
   registration: RegisteredProperty,
 ): ValidationDiagnostic {
   return {
@@ -278,7 +219,7 @@ function toAssignmentDiagnostic(
 
 function toFallbackDiagnostic(
   filePath: string,
-  declaration: any,
+  declaration: CssDeclarationNode,
   registration: RegisteredProperty,
   varNode: VarFunctionNode,
 ): ValidationDiagnostic {
@@ -294,125 +235,14 @@ function toFallbackDiagnostic(
   };
 }
 
-function isCompatibleWithSubstitutions(
-  valueSource: string,
-  occurrences: VarOccurrence[],
-  substitutionOptions: Array<{ samples: string[]; varNode: VarFunctionNode }>,
-  matcher: Matcher,
-  index = 0,
-  activeSubstitutions: ActiveSubstitution[] = [],
-): boolean {
-  if (index === substitutionOptions.length) {
-    return valueMatchesSamples(valueSource, occurrences, activeSubstitutions, matcher);
-  }
-
-  const option = substitutionOptions[index];
-
-  return option.samples.some((sample) =>
-    isCompatibleWithSubstitutions(valueSource, occurrences, substitutionOptions, matcher, index + 1, [
-      ...activeSubstitutions,
-      { sample, varNode: option.varNode },
-    ]),
-  );
-}
-
-function canDeclarationMatchWithoutOccurrence(
-  valueSource: string,
-  occurrences: VarOccurrence[],
-  substitutionOptions: SubstitutionOption[],
-  matcher: Matcher,
-  removedIndex: number,
-  optionIndex = 0,
-  replacements: Array<string | null> = Array.from({ length: occurrences.length }, () => null),
-): boolean {
-  if (optionIndex === substitutionOptions.length) {
-    const renderedSource = renderValueWithReplacements(valueSource, occurrences, replacements);
-    return valueMatchesRenderedSource(renderedSource, matcher);
-  }
-
-  const option = substitutionOptions[optionIndex];
-
-  if (option.index === removedIndex) {
-    return canDeclarationMatchWithoutOccurrence(
-      valueSource,
-      occurrences,
-      substitutionOptions,
-      matcher,
-      removedIndex,
-      optionIndex + 1,
-      replacements,
-    );
-  }
-
-  return option.samples.some((sample) => {
-    const nextReplacements = [...replacements];
-    nextReplacements[option.index] = sample;
-
-    return canDeclarationMatchWithoutOccurrence(
-      valueSource,
-      occurrences,
-      substitutionOptions,
-      matcher,
-      removedIndex,
-      optionIndex + 1,
-      nextReplacements,
-    );
-  });
-}
-
-// This helper answers a narrower fallback-specific question than the normal
-// representative-sample check: if one var() occurrence resolves to its authored
-// fallback branch while the other registered occurrences keep using compatible
-// samples, can the full declaration still match the consuming property?
-function canDeclarationMatchWithOccurrenceReplacement(
-  context: ReplacementCheckContext,
-  replacedIndex: number,
-  replacementSource: string,
-  optionIndex = 0,
-  replacements: Array<string | null> = Array.from({ length: context.occurrences.length }, () => null),
-): boolean {
-  if (optionIndex === context.substitutionOptions.length) {
-    const renderedSource = renderValueWithReplacements(
-      context.valueSource,
-      context.occurrences,
-      replacements,
-    );
-    return valueMatchesRenderedSource(renderedSource, context.matcher);
-  }
-
-  const option = context.substitutionOptions[optionIndex];
-
-  if (option.index === replacedIndex) {
-    const nextReplacements = [...replacements];
-    nextReplacements[replacedIndex] = replacementSource;
-
-    return canDeclarationMatchWithOccurrenceReplacement(
-      context,
-      replacedIndex,
-      replacementSource,
-      optionIndex + 1,
-      nextReplacements,
-    );
-  }
-
-  return option.samples.some((sample) => {
-    const nextReplacements = [...replacements];
-    nextReplacements[option.index] = sample;
-
-    return canDeclarationMatchWithOccurrenceReplacement(
-      context,
-      replacedIndex,
-      replacementSource,
-      optionIndex + 1,
-      nextReplacements,
-    );
-  });
-}
-
 function toPreciseMultiVarDiagnostic(
   filePath: string,
-  declaration: any,
-  registeredEntries: Array<{ index: number; registration: RegisteredProperty; varNode: VarFunctionNode }>,
+  declaration: CssDeclarationNode,
+  registeredEntries: Array<{
+    index: number;
+    registration: RegisteredProperty;
+    varNode: VarFunctionNode;
+  }>,
   valueSource: string,
   occurrences: VarOccurrence[],
   substitutionOptions: SubstitutionOption[],
@@ -461,7 +291,7 @@ function toPreciseMultiVarDiagnostic(
 
 function validateDeclaration(
   filePath: string,
-  declaration: any,
+  declaration: CssDeclarationNode,
   registry: Map<string, RegisteredProperty>,
 ): { diagnostics: ValidationDiagnostic[]; skipped: number; validated: number } {
   const diagnostics: ValidationDiagnostic[] = [];
@@ -506,7 +336,7 @@ function validateDeclaration(
 
     return {
       propertyName,
-      registration: propertyName ? registry.get(propertyName) ?? null : null,
+      registration: propertyName ? (registry.get(propertyName) ?? null) : null,
       varNode,
     };
   });
@@ -522,7 +352,7 @@ function validateDeclaration(
     ): entry is {
       propertyName: string;
       registration: RegisteredProperty;
-      varNode: any;
+      varNode: VarFunctionNode;
     } => Boolean(entry.registration),
   );
 
@@ -560,13 +390,16 @@ function validateDeclaration(
   }
 
   const valueSource = cssTree.generate(valueToValidate);
-  const occurrences = collectVarOccurrences(valueSource, registeredEntries.map((entry) => entry.varNode));
+  const occurrences = collectVarOccurrences(
+    valueSource,
+    registeredEntries.map((entry) => entry.varNode),
+  );
 
   if (!occurrences) {
     return { diagnostics, skipped: 1, validated: 0 };
   }
 
-  const substitutionOptions = [];
+  const substitutionOptions: SubstitutionOption[] = [];
 
   for (const [index, entry] of registeredEntries.entries()) {
     let samples: string[];
@@ -590,9 +423,12 @@ function validateDeclaration(
   }
 
   const matcher = isCustomPropertyName(declaration.property)
-    ? (candidateValue: any) =>
-        matchRegisteredSyntax(registry.get(declaration.property) as RegisteredProperty, candidateValue)
-    : (candidateValue: any) => {
+    ? (candidateValue: CssValueAst) =>
+        matchRegisteredSyntax(
+          registry.get(declaration.property) as RegisteredProperty,
+          candidateValue,
+        )
+    : (candidateValue: CssValueAst) => {
         const match = cssTree.lexer.matchProperty(declaration.property, candidateValue);
         return Boolean(match?.matched);
       };
@@ -663,7 +499,11 @@ function validateDeclaration(
   if (!isCompatible) {
     if (isCustomPropertyName(declaration.property)) {
       diagnostics.push(
-        toAssignmentDiagnostic(filePath, declaration, registry.get(declaration.property) as RegisteredProperty),
+        toAssignmentDiagnostic(
+          filePath,
+          declaration,
+          registry.get(declaration.property) as RegisteredProperty,
+        ),
       );
     } else {
       // When several registered var() calls participate in one declaration,
@@ -713,7 +553,7 @@ export function validateFiles(
   let validatedDeclarations = 0;
 
   for (const input of inputs) {
-    let ast: any;
+    let ast: CssValueAst;
 
     try {
       ast = cssTree.parse(input.css, {
@@ -726,8 +566,8 @@ export function validateFiles(
 
     cssTree.walk(ast, {
       visit: "Declaration",
-      enter(node: any) {
-        const result = validateDeclaration(input.path, node, registry);
+      enter(node: CssWalkNode) {
+        const result = validateDeclaration(input.path, node as CssDeclarationNode, registry);
         diagnostics.push(...result.diagnostics);
         skippedDeclarations += result.skipped;
         validatedDeclarations += result.validated;

--- a/packages/core/src/var-substitution.ts
+++ b/packages/core/src/var-substitution.ts
@@ -1,0 +1,258 @@
+import * as cssTree from "css-tree";
+
+import type { SourceLocation } from "./types.js";
+
+// Helpers for compatibility checks that replace registered var() calls with
+// representative sample values or fallback branches. This intentionally answers
+// "can the rendered value match?" rather than trying to model the full CSS
+// cascade or computed-value substitution behavior.
+export type CssValueAst = unknown;
+export type Matcher = (candidateValue: CssValueAst) => boolean;
+
+export interface CssNodeList<TNode> {
+  first?: TNode;
+  toArray?: () => TNode[];
+}
+
+export interface CssNodeWithLoc {
+  loc?: SourceLocation | null;
+  name?: string;
+  type?: string;
+  value?: string;
+}
+
+export interface VarFunctionNode {
+  children?: CssNodeList<CssNodeWithLoc> | CssNodeWithLoc[];
+  loc?: SourceLocation | null;
+  name?: string;
+}
+
+export interface VarOccurrence {
+  end: number;
+  start: number;
+  varNode: VarFunctionNode;
+}
+
+export interface SubstitutionOption {
+  index: number;
+  samples: string[];
+  varNode: VarFunctionNode;
+}
+
+export interface ActiveSubstitution {
+  sample: string;
+  varNode: VarFunctionNode;
+}
+
+export interface ReplacementCheckContext {
+  matcher: Matcher;
+  occurrences: VarOccurrence[];
+  substitutionOptions: SubstitutionOption[];
+  valueSource: string;
+}
+
+function parseValue(value: string): CssValueAst | null {
+  try {
+    return cssTree.parse(value, { context: "value" }) as CssValueAst;
+  } catch {
+    return null;
+  }
+}
+
+export function collectVarOccurrences(
+  valueSource: string,
+  varNodes: VarFunctionNode[],
+): VarOccurrence[] | null {
+  const occurrences: VarOccurrence[] = [];
+  let searchStart = 0;
+
+  for (const varNode of varNodes) {
+    // Generated source gives us deterministic replacement ranges for the
+    // normalized declaration value, including repeated var() calls.
+    const replacementTarget = cssTree.generate(varNode);
+    const start = valueSource.indexOf(replacementTarget, searchStart);
+
+    if (start === -1) {
+      return null;
+    }
+
+    const end = start + replacementTarget.length;
+
+    occurrences.push({ start, end, varNode });
+    searchStart = end;
+  }
+
+  return occurrences;
+}
+
+function renderValueWithReplacements(
+  valueSource: string,
+  occurrences: VarOccurrence[],
+  replacements: Array<string | null>,
+): string {
+  let rendered = "";
+  let cursor = 0;
+
+  for (const [index, occurrence] of occurrences.entries()) {
+    rendered += valueSource.slice(cursor, occurrence.start);
+    rendered += replacements[index] ?? "";
+    cursor = occurrence.end;
+  }
+
+  rendered += valueSource.slice(cursor);
+
+  return rendered.trim();
+}
+
+function valueMatchesRenderedSource(renderedSource: string, matcher: Matcher): boolean {
+  const replacedAst = parseValue(renderedSource);
+
+  if (!replacedAst) {
+    return false;
+  }
+
+  return matcher(replacedAst);
+}
+
+function valueMatchesSamples(
+  valueSource: string,
+  occurrences: VarOccurrence[],
+  substitutions: ActiveSubstitution[],
+  matcher: Matcher,
+): boolean {
+  const replacementMap = new Map(
+    substitutions.map((substitution) => [substitution.varNode, substitution.sample]),
+  );
+  const renderedSource = renderValueWithReplacements(
+    valueSource,
+    occurrences,
+    occurrences.map((occurrence) => replacementMap.get(occurrence.varNode) ?? null),
+  );
+
+  return valueMatchesRenderedSource(renderedSource, matcher);
+}
+
+export function isCompatibleWithSubstitutions(
+  valueSource: string,
+  occurrences: VarOccurrence[],
+  substitutionOptions: Array<{ samples: string[]; varNode: VarFunctionNode }>,
+  matcher: Matcher,
+  index = 0,
+  activeSubstitutions: ActiveSubstitution[] = [],
+): boolean {
+  if (index === substitutionOptions.length) {
+    return valueMatchesSamples(valueSource, occurrences, activeSubstitutions, matcher);
+  }
+
+  const option = substitutionOptions[index];
+
+  return option.samples.some((sample) =>
+    isCompatibleWithSubstitutions(
+      valueSource,
+      occurrences,
+      substitutionOptions,
+      matcher,
+      index + 1,
+      [...activeSubstitutions, { sample, varNode: option.varNode }],
+    ),
+  );
+}
+
+export function canDeclarationMatchWithoutOccurrence(
+  valueSource: string,
+  occurrences: VarOccurrence[],
+  substitutionOptions: SubstitutionOption[],
+  matcher: Matcher,
+  removedIndex: number,
+  optionIndex = 0,
+  replacements: Array<string | null> = Array.from({ length: occurrences.length }, () => null),
+): boolean {
+  if (optionIndex === substitutionOptions.length) {
+    const renderedSource = renderValueWithReplacements(valueSource, occurrences, replacements);
+    return valueMatchesRenderedSource(renderedSource, matcher);
+  }
+
+  const option = substitutionOptions[optionIndex];
+
+  // Multi-var() diagnostics use this to isolate likely culprits: if removing
+  // exactly one occurrence lets the remaining substitutions match, that
+  // occurrence is a useful diagnostic target.
+  if (option.index === removedIndex) {
+    return canDeclarationMatchWithoutOccurrence(
+      valueSource,
+      occurrences,
+      substitutionOptions,
+      matcher,
+      removedIndex,
+      optionIndex + 1,
+      replacements,
+    );
+  }
+
+  return option.samples.some((sample) => {
+    const nextReplacements = [...replacements];
+    nextReplacements[option.index] = sample;
+
+    return canDeclarationMatchWithoutOccurrence(
+      valueSource,
+      occurrences,
+      substitutionOptions,
+      matcher,
+      removedIndex,
+      optionIndex + 1,
+      nextReplacements,
+    );
+  });
+}
+
+// This helper answers a narrower fallback-specific question than the normal
+// representative-sample check: if one var() occurrence resolves to its authored
+// fallback branch while the other registered occurrences keep using compatible
+// samples, can the full declaration still match the consuming property?
+export function canDeclarationMatchWithOccurrenceReplacement(
+  context: ReplacementCheckContext,
+  replacedIndex: number,
+  replacementSource: string,
+  optionIndex = 0,
+  replacements: Array<string | null> = Array.from(
+    { length: context.occurrences.length },
+    () => null,
+  ),
+): boolean {
+  if (optionIndex === context.substitutionOptions.length) {
+    const renderedSource = renderValueWithReplacements(
+      context.valueSource,
+      context.occurrences,
+      replacements,
+    );
+    return valueMatchesRenderedSource(renderedSource, context.matcher);
+  }
+
+  const option = context.substitutionOptions[optionIndex];
+
+  if (option.index === replacedIndex) {
+    const nextReplacements = [...replacements];
+    nextReplacements[replacedIndex] = replacementSource;
+
+    return canDeclarationMatchWithOccurrenceReplacement(
+      context,
+      replacedIndex,
+      replacementSource,
+      optionIndex + 1,
+      nextReplacements,
+    );
+  }
+
+  return option.samples.some((sample) => {
+    const nextReplacements = [...replacements];
+    nextReplacements[option.index] = sample;
+
+    return canDeclarationMatchWithOccurrenceReplacement(
+      context,
+      replacedIndex,
+      replacementSource,
+      optionIndex + 1,
+      nextReplacements,
+    );
+  });
+}

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -1,7 +1,8 @@
 import { spawnSync } from "node:child_process";
-import { mkdtempSync, writeFileSync } from "node:fs";
+import { mkdtempSync, readFileSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { pathToFileURL } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
@@ -118,7 +119,9 @@ describe("validateFiles", () => {
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
-    expect(result.diagnostics[0]?.message).toContain("missing the required initial-value descriptor");
+    expect(result.diagnostics[0]?.message).toContain(
+      "missing the required initial-value descriptor",
+    );
     expect(result.registry).toHaveLength(0);
   });
 
@@ -140,7 +143,9 @@ describe("validateFiles", () => {
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
-    expect(result.diagnostics[0]?.message).toContain('does not match its syntax descriptor "<color>"');
+    expect(result.diagnostics[0]?.message).toContain(
+      'does not match its syntax descriptor "<color>"',
+    );
     expect(result.registry).toHaveLength(0);
   });
 
@@ -152,7 +157,9 @@ describe("validateFiles", () => {
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
-    expect(result.diagnostics[0]?.message).toContain('uses the relative or context-dependent unit "em"');
+    expect(result.diagnostics[0]?.message).toContain(
+      'uses the relative or context-dependent unit "em"',
+    );
     expect(result.registry).toHaveLength(0);
   });
 
@@ -325,7 +332,7 @@ describe("validateFiles", () => {
     const result = runValidation({
       "/tmp/registry.css":
         '@property --anything { syntax: "*"; inherits: false; initial-value: 0px; }',
-      "/tmp/usage.css": ':root { --anything: clamp(1rem, 2vw, 3rem); }',
+      "/tmp/usage.css": ":root { --anything: clamp(1rem, 2vw, 3rem); }",
     });
 
     expect(result.diagnostics).toHaveLength(0);
@@ -350,7 +357,7 @@ describe("validateFiles", () => {
   it("reports an incompatible fallback value for a registered var() usage", () => {
     const result = runValidation({
       "/tmp/tokens.css": SHARED_REGISTRY,
-      "/tmp/component.css": '.card { color: var(--brand-color, 10px); }',
+      "/tmp/component.css": ".card { color: var(--brand-color, 10px); }",
     });
 
     expect(result.diagnostics).toHaveLength(1);
@@ -381,7 +388,7 @@ describe("validateFiles", () => {
   it("skips assignment-site fallback validation for now", () => {
     const result = runValidation({
       "/tmp/tokens.css": SHARED_REGISTRY,
-      "/tmp/component.css": ':root { --space-md: var(--space-sm, red); }',
+      "/tmp/component.css": ":root { --space-md: var(--space-sm, red); }",
     });
 
     expect(result.diagnostics).toHaveLength(0);
@@ -392,7 +399,7 @@ describe("validateFiles", () => {
   it("skips nested fallback chains until fallback reachability is modeled", () => {
     const result = runValidation({
       "/tmp/tokens.css": SHARED_REGISTRY,
-      "/tmp/component.css": '.card { color: var(--brand-color, var(--accent-color, blue)); }',
+      "/tmp/component.css": ".card { color: var(--brand-color, var(--accent-color, blue)); }",
     });
 
     expect(result.diagnostics).toHaveLength(0);
@@ -589,10 +596,9 @@ describe("validateFiles", () => {
         '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
     };
 
-    const result = validateFiles(
-      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
-      { resolveImport: createTestResolver(cssByPath) },
-    );
+    const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      resolveImport: createTestResolver(cssByPath),
+    });
 
     expect(result.diagnostics).toHaveLength(0);
     expect(result.registry).toHaveLength(1);
@@ -629,10 +635,9 @@ describe("validateFiles", () => {
         '@property --hero-url { syntax: "<url>"; inherits: false; initial-value: url("https://example.com/hero.png"); }',
     };
 
-    const result = validateFiles(
-      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
-      { resolveImport: createTestResolver(cssByPath) },
-    );
+    const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      resolveImport: createTestResolver(cssByPath),
+    });
 
     expect(result.diagnostics).toHaveLength(0);
     expect(result.registry[0]?.filePath).toBe("/tokens/root.css");
@@ -648,10 +653,9 @@ describe("validateFiles", () => {
       ].join("\n"),
     };
 
-    const result = validateFiles(
-      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
-      { resolveImport: createTestResolver(cssByPath) },
-    );
+    const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      resolveImport: createTestResolver(cssByPath),
+    });
 
     expect(result.diagnostics).toHaveLength(0);
     expect(result.validatedDeclarations).toBe(1);
@@ -668,10 +672,9 @@ describe("validateFiles", () => {
         '@property --surface-token { syntax: "<color>"; inherits: true; initial-value: white; }',
     };
 
-    const result = validateFiles(
-      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
-      { resolveImport: createTestResolver(cssByPath) },
-    );
+    const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      resolveImport: createTestResolver(cssByPath),
+    });
 
     expect(result.registry).toHaveLength(1);
     expect(result.registry[0]?.filePath).toBe("/tmp/main.css");
@@ -690,10 +693,9 @@ describe("validateFiles", () => {
       ].join("\n"),
     };
 
-    const result = validateFiles(
-      [{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }],
-      { resolveImport: createTestResolver(cssByPath) },
-    );
+    const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      resolveImport: createTestResolver(cssByPath),
+    });
 
     expect(result.diagnostics).toHaveLength(0);
     expect(result.registry).toHaveLength(1);
@@ -833,12 +835,12 @@ describe("validateFiles", () => {
     };
 
     expect(report.diagnostics).toHaveLength(21);
-    expect(report.diagnostics.some((diagnostic) => diagnostic.code === "invalid-property-registration")).toBe(
-      true,
-    );
-    expect(report.diagnostics.some((diagnostic) => diagnostic.expectedProperty === "inline-size")).toBe(
-      true,
-    );
+    expect(
+      report.diagnostics.some((diagnostic) => diagnostic.code === "invalid-property-registration"),
+    ).toBe(true);
+    expect(
+      report.diagnostics.some((diagnostic) => diagnostic.expectedProperty === "inline-size"),
+    ).toBe(true);
     expect(
       report.diagnostics.some(
         (diagnostic) =>
@@ -881,6 +883,89 @@ describe("validateFiles", () => {
     expect(report.validatedDeclarations).toBe(32);
   });
 
+  it("documents key CLI options in --help output", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const cliResult = spawnSync("node", ["packages/cli/dist/cli.js", "--help"], {
+      cwd: repoRoot,
+      encoding: "utf8",
+    });
+
+    expect(cliResult.status).toBe(0);
+    expect(cliResult.stdout).toContain("--format");
+    expect(cliResult.stdout).toContain("--registry");
+    expect(cliResult.stdout).toContain("--registry-only");
+  });
+
+  it("keeps human CLI output stable for a clean validation run", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const validationPath = path.join(fixtureDir, "component.css");
+    const registryPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(validationPath, ".card { inline-size: var(--space); }\n");
+    writeFileSync(
+      registryPath,
+      '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }\n',
+    );
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", validationPath, "--registry", registryPath],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(0);
+    expect(cliResult.stdout.trim()).toBe("No validation issues found.");
+  });
+
+  it("keeps human CLI output stable for a diagnostic", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const validationPath = path.join(fixtureDir, "component.css");
+    const registryPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(validationPath, ".card { inline-size: var(--brand-color); }\n");
+    writeFileSync(
+      registryPath,
+      '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }\n',
+    );
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", validationPath, "--registry", registryPath],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(1);
+    expect(cliResult.stdout).toContain(`${validationPath}:1:22 incompatible-var-usage`);
+    expect(cliResult.stdout).toContain(
+      'Registered property --brand-color uses syntax "<color>" which is incompatible with inline-size at this var() usage.',
+    );
+    expect(cliResult.stdout).toContain("inline-size:var(--brand-color)");
+  });
+
+  it("builds the public runtime and type exports", { timeout: 120000 }, async () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const builtCore = await import(
+      pathToFileURL(path.join(repoRoot, "packages/core/dist/index.js")).href
+    );
+    const declarationFile = readFileSync(
+      path.join(repoRoot, "packages/core/dist/index.d.ts"),
+      "utf8",
+    );
+
+    expect(typeof builtCore.validateFiles).toBe("function");
+    expect(declarationFile).toContain("ValidateFilesOptions");
+    expect(declarationFile).toContain("ValidationDiagnostic");
+    expect(declarationFile).toContain("ValidationResult");
+  });
+
   it("supports registry-only CLI inputs", { timeout: 120000 }, () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../..");
     const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
@@ -895,14 +980,7 @@ describe("validateFiles", () => {
 
     const cliResult = spawnSync(
       "node",
-      [
-        "packages/cli/dist/cli.js",
-        validationPath,
-        "--registry",
-        registryPath,
-        "--format",
-        "json",
-      ],
+      ["packages/cli/dist/cli.js", validationPath, "--registry", registryPath, "--format", "json"],
       {
         cwd: repoRoot,
         encoding: "utf8",
@@ -935,13 +1013,7 @@ describe("validateFiles", () => {
 
     const cliResult = spawnSync(
       "node",
-      [
-        "packages/cli/dist/cli.js",
-        registryPath,
-        "--registry-only",
-        "--format",
-        "json",
-      ],
+      ["packages/cli/dist/cli.js", registryPath, "--registry-only", "--format", "json"],
       {
         cwd: repoRoot,
         encoding: "utf8",
@@ -962,86 +1034,88 @@ describe("validateFiles", () => {
     expect(report.validatedDeclarations).toBe(0);
   });
 
-  it("reports invalid registrations in explicit registration-only CLI mode", { timeout: 120000 }, () => {
-    const repoRoot = path.resolve(import.meta.dirname, "../../..");
-    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
-    const registryPath = path.join(fixtureDir, "tokens.css");
+  it(
+    "reports invalid registrations in explicit registration-only CLI mode",
+    { timeout: 120000 },
+    () => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+      const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+      const registryPath = path.join(fixtureDir, "tokens.css");
 
-    writeFileSync(
-      registryPath,
-      '@property --bad { syntax: "<color"; inherits: true; initial-value: transparent; }\n',
-    );
-
-    const cliResult = spawnSync(
-      "node",
-      [
-        "packages/cli/dist/cli.js",
+      writeFileSync(
         registryPath,
-        "--registry-only",
-        "--format",
-        "json",
-      ],
-      {
+        '@property --bad { syntax: "<color"; inherits: true; initial-value: transparent; }\n',
+      );
+
+      const cliResult = spawnSync(
+        "node",
+        ["packages/cli/dist/cli.js", registryPath, "--registry-only", "--format", "json"],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+        },
+      );
+
+      expect(cliResult.status).toBe(1);
+
+      const report = JSON.parse(cliResult.stdout) as {
+        diagnostics: Array<{ code: string; filePath: string }>;
+        validatedDeclarations: number;
+      };
+
+      expect(report.diagnostics).toHaveLength(1);
+      expect(report.diagnostics[0]?.code).toBe("invalid-property-registration");
+      expect(report.diagnostics[0]?.filePath).toBe(registryPath);
+      expect(report.validatedDeclarations).toBe(0);
+    },
+  );
+
+  it(
+    "returns exit code 2 when registration-only patterns do not match",
+    { timeout: 120000 },
+    () => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+      const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+
+      const cliResult = spawnSync(
+        "node",
+        [
+          "packages/cli/dist/cli.js",
+          path.join(fixtureDir, "missing-*.css"),
+          "--registry-only",
+          "--format",
+          "json",
+        ],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+        },
+      );
+
+      expect(cliResult.status).toBe(2);
+      expect(cliResult.stderr).toContain(
+        "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.",
+      );
+    },
+  );
+
+  it(
+    "returns the normal validation-input error when no validation patterns are provided",
+    { timeout: 120000 },
+    () => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+
+      const cliResult = spawnSync("node", ["packages/cli/dist/cli.js", "--format", "json"], {
         cwd: repoRoot,
         encoding: "utf8",
-      },
-    );
+      });
 
-    expect(cliResult.status).toBe(1);
-
-    const report = JSON.parse(cliResult.stdout) as {
-      diagnostics: Array<{ code: string; filePath: string }>;
-      validatedDeclarations: number;
-    };
-
-    expect(report.diagnostics).toHaveLength(1);
-    expect(report.diagnostics[0]?.code).toBe("invalid-property-registration");
-    expect(report.diagnostics[0]?.filePath).toBe(registryPath);
-    expect(report.validatedDeclarations).toBe(0);
-  });
-
-  it("returns exit code 2 when registration-only patterns do not match", { timeout: 120000 }, () => {
-    const repoRoot = path.resolve(import.meta.dirname, "../../..");
-    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
-
-    const cliResult = spawnSync(
-      "node",
-      [
-        "packages/cli/dist/cli.js",
-        path.join(fixtureDir, "missing-*.css"),
-        "--registry-only",
-        "--format",
-        "json",
-      ],
-      {
-        cwd: repoRoot,
-        encoding: "utf8",
-      },
-    );
-
-    expect(cliResult.status).toBe(2);
-    expect(cliResult.stderr).toContain(
-      "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.",
-    );
-  });
-
-  it("returns the normal validation-input error when no validation patterns are provided", { timeout: 120000 }, () => {
-    const repoRoot = path.resolve(import.meta.dirname, "../../..");
-
-    const cliResult = spawnSync(
-      "node",
-      ["packages/cli/dist/cli.js", "--format", "json"],
-      {
-        cwd: repoRoot,
-        encoding: "utf8",
-      },
-    );
-
-    expect(cliResult.status).toBe(2);
-    expect(cliResult.stderr).toContain(
-      "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.",
-    );
-  });
+      expect(cliResult.status).toBe(2);
+      expect(cliResult.stderr).toContain(
+        "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.",
+      );
+    },
+  );
 
   it("includes registry-only diagnostics in CLI json output", { timeout: 120000 }, () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../..");
@@ -1057,14 +1131,7 @@ describe("validateFiles", () => {
 
     const cliResult = spawnSync(
       "node",
-      [
-        "packages/cli/dist/cli.js",
-        validationPath,
-        "--registry",
-        registryPath,
-        "--format",
-        "json",
-      ],
+      ["packages/cli/dist/cli.js", validationPath, "--registry", registryPath, "--format", "json"],
       {
         cwd: repoRoot,
         encoding: "utf8",
@@ -1090,7 +1157,10 @@ describe("validateFiles", () => {
     const validationPath = path.join(fixtureDir, "component.css");
     const registryPath = path.join(fixtureDir, "tokens.css");
 
-    writeFileSync(validationPath, '@import "./tokens.css";\n.card { inline-size: var(--space); }\n');
+    writeFileSync(
+      validationPath,
+      '@import "./tokens.css";\n.card { inline-size: var(--space); }\n',
+    );
     writeFileSync(
       registryPath,
       '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }\n',

--- a/scripts/check-supported-syntax-names.mjs
+++ b/scripts/check-supported-syntax-names.mjs
@@ -17,7 +17,7 @@ function extractSupportedNames(documentText) {
 
   while (currentNode.length > 0 && currentNode.attr("id") !== "multipliers") {
     if (currentNode.is("dl")) {
-      currentNode.find('dt[data-md]').each((_, element) => {
+      currentNode.find("dt[data-md]").each((_, element) => {
         const text = $(element).text().trim();
         const quotedNameMatch = text.match(/^"(<[\w-]+>)"$/);
 
@@ -71,6 +71,6 @@ async function main() {
 }
 
 main().catch((error) => {
-  process.stderr.write(`${(error instanceof Error ? error.message : String(error))}\n`);
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary

This PR takes stock of the current project and tightens the contributor experience without changing the public API or CLI behavior.

- Adds root feedback-loop scripts for formatting, linting, type checking, tests, and builds.
- Updates CI to run format and lint checks before the existing typecheck/test/build steps.
- Adds `CONTRIBUTING.md` with setup, validation, testing, and release guidance.
- Refreshes the root README, package READMEs, and roadmap so new users can understand what the project does, why it is useful, and how to use it.
- Extracts `var()` substitution logic into a focused helper module and reduces parser-adjacent type debt in the core implementation.
- Adds regression coverage for CLI help text, human output, built public exports, and the refactored validation paths.

## Why

The validator already had a strong behavioral foundation. This PR makes the repo easier to approach, easier to verify locally, and easier to maintain as validation behavior grows.

## Validation

- `pnpm run check`
- `pnpm run check:supported-syntax-names`

## Notes

- Public package exports and CLI behavior are intended to remain unchanged.
- The `css-tree` declaration shim remains the boundary for parser types; the new internal types only contain the parser shapes this package actually uses.
