### PR TITLE
[codex] add browser validator app

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,7 @@ dist
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vite/
+
+# Playwright
+test-results/
+playwright-report/

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "build": "pnpm -r --if-present run build",
     "test": "vp test run",
+    "test:e2e": "pnpm --filter @schalkneethling/css-property-type-validator-web test:e2e",
     "typecheck": "tsc -b tsconfig.json",
     "check:supported-syntax-names": "node scripts/check-supported-syntax-names.mjs",
     "clean": "node scripts/clean.mjs",

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -7,8 +7,10 @@ import process from "node:process";
 
 import { Command } from "commander";
 
-import { validateFiles } from "@schalkneethling/css-property-type-validator-core";
-import { formatValidationResult } from "./formatter.js";
+import {
+  formatValidationResult,
+  validateFiles,
+} from "@schalkneethling/css-property-type-validator-core";
 
 import type {
   ResolveImport,

--- a/packages/core/src/formatter.ts
+++ b/packages/core/src/formatter.ts
@@ -1,9 +1,6 @@
-import type {
-  ValidationDiagnostic,
-  ValidationResult,
-} from "@schalkneethling/css-property-type-validator-core";
+import type { ValidationDiagnostic, ValidationResult } from "./types.js";
 
-type OutputFormat = "human" | "json";
+export type OutputFormat = "human" | "json";
 
 function formatLocation(diagnostic: ValidationDiagnostic): string {
   if (!diagnostic.loc) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,7 @@
 export { validateFiles } from "./validate.js";
 export type { ValidateFilesOptions } from "./validate.js";
+export { formatValidationResult } from "./formatter.js";
+export type { OutputFormat } from "./formatter.js";
 
 export type {
   RegisteredProperty,

--- a/packages/core/test/formatter.test.ts
+++ b/packages/core/test/formatter.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "vitest";
+
+import { formatValidationResult } from "../src/formatter.js";
+
+import type { ValidationResult } from "../src/types.js";
+
+const PASSING_RESULT: ValidationResult = {
+  diagnostics: [],
+  registry: [],
+  skippedDeclarations: 0,
+  validatedDeclarations: 1,
+};
+
+describe("formatValidationResult", () => {
+  it("formats a passing result for human output", () => {
+    expect(formatValidationResult(PASSING_RESULT, "human")).toBe("No validation issues found.");
+  });
+
+  it("formats diagnostics with locations and snippets for human output", () => {
+    const result: ValidationResult = {
+      diagnostics: [
+        {
+          code: "incompatible-var-usage",
+          expectedProperty: "inline-size",
+          filePath: "component.css",
+          loc: {
+            start: { column: 3, line: 8, offset: 120 },
+            end: { column: 33, line: 8, offset: 150 },
+          },
+          message: "Registered property --brand-color is incompatible.",
+          propertyName: "--brand-color",
+          registeredSyntax: "<color>",
+          snippet: "inline-size:var(--brand-color)",
+        },
+      ],
+      registry: [],
+      skippedDeclarations: 0,
+      validatedDeclarations: 1,
+    };
+
+    expect(formatValidationResult(result, "human")).toBe(
+      [
+        "component.css:8:3 incompatible-var-usage",
+        "Registered property --brand-color is incompatible.",
+        "  inline-size:var(--brand-color)",
+      ].join("\n"),
+    );
+  });
+
+  it("formats the complete result as pretty JSON", () => {
+    expect(formatValidationResult(PASSING_RESULT, "json")).toBe(
+      JSON.stringify(PASSING_RESULT, null, 2),
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,7 +19,7 @@ importers:
         version: 6.0.2
       vite-plus:
         specifier: ^0.1.18
-        version: 0.1.18(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0))
+        version: 0.1.18(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.6.0))
 
   packages/cli:
     dependencies:
@@ -38,21 +38,94 @@ importers:
     devDependencies:
       vitest:
         specifier: ^4.1.4
-        version: 4.1.4(@types/node@25.6.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0))
+        version: 4.1.4(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0))
+
+  web:
+    dependencies:
+      '@codemirror/lang-css':
+        specifier: 6.3.1
+        version: 6.3.1
+      '@codemirror/lang-json':
+        specifier: 6.0.2
+        version: 6.0.2
+      '@codemirror/state':
+        specifier: 6.6.0
+        version: 6.6.0
+      '@codemirror/view':
+        specifier: 6.41.1
+        version: 6.41.1
+      '@schalkneethling/css-property-type-validator-core':
+        specifier: workspace:*
+        version: link:../packages/core
+      codemirror:
+        specifier: 6.0.2
+        version: 6.0.2
+      vite:
+        specifier: 8.0.10
+        version: 8.0.10(@types/node@25.6.0)
+    devDependencies:
+      '@playwright/test':
+        specifier: 1.59.1
+        version: 1.59.1
 
 packages:
 
-  '@emnapi/core@1.9.1':
-    resolution: {integrity: sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==}
+  '@codemirror/autocomplete@6.20.1':
+    resolution: {integrity: sha512-1cvg3Vz1dSSToCNlJfRA2WSI4ht3K+WplO0UMOgmUYPivCyy2oueZY6Lx7M9wThm7SDUBViRmuT+OG/i8+ON9A==}
 
-  '@emnapi/runtime@1.9.1':
-    resolution: {integrity: sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==}
+  '@codemirror/commands@6.10.3':
+    resolution: {integrity: sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q==}
 
-  '@emnapi/wasi-threads@1.2.0':
-    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
+  '@codemirror/lang-css@6.3.1':
+    resolution: {integrity: sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg==}
+
+  '@codemirror/lang-json@6.0.2':
+    resolution: {integrity: sha512-x2OtO+AvwEHrEwR0FyyPtfDUiloG3rnVTSZV1W8UteaLL8/MajQd8DpvUb2YVzC+/T18aSDv0H9mu+xw0EStoQ==}
+
+  '@codemirror/language@6.12.3':
+    resolution: {integrity: sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA==}
+
+  '@codemirror/lint@6.9.5':
+    resolution: {integrity: sha512-GElsbU9G7QT9xXhpUg1zWGmftA/7jamh+7+ydKRuT0ORpWS3wOSP0yT1FOlIZa7mIJjpVPipErsyvVqB9cfTFA==}
+
+  '@codemirror/search@6.7.0':
+    resolution: {integrity: sha512-ZvGm99wc/s2cITtMT15LFdn8aH/aS+V+DqyGq/N5ZlV5vWtH+nILvC2nw0zX7ByNoHHDZ2IxxdW38O0tc5nVHg==}
+
+  '@codemirror/state@6.6.0':
+    resolution: {integrity: sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ==}
+
+  '@codemirror/view@6.41.1':
+    resolution: {integrity: sha512-ToDnWKbBnke+ZLrP6vgTTDScGi5H37YYuZGniQaBzxMVdtCxMrslsmtnOvbPZk4RX9bvkQqnWR/WS/35tJA0qg==}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@lezer/common@1.5.2':
+    resolution: {integrity: sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==}
+
+  '@lezer/css@1.3.3':
+    resolution: {integrity: sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg==}
+
+  '@lezer/highlight@1.2.3':
+    resolution: {integrity: sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==}
+
+  '@lezer/json@1.0.3':
+    resolution: {integrity: sha512-BP9KzdF9Y35PDpv04r0VeSTKDeox5vVr3efE7eBbx3r4s3oNLfunchejZhjArmeieBH+nVOpgIiBJpEAv8ilqQ==}
+
+  '@lezer/lr@1.4.10':
+    resolution: {integrity: sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==}
+
+  '@marijn/find-cluster-break@1.0.2':
+    resolution: {integrity: sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==}
 
   '@napi-rs/wasm-runtime@1.1.4':
     resolution: {integrity: sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==}
@@ -64,11 +137,11 @@ packages:
     resolution: {integrity: sha512-sSg6n37J3w3mM4odFvRqzQENf6+qxKnvStr/gU0FgRRg1VE/4MqryLd9PJmE0a7K5xlDfbrctBtSagaFH6ij9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
 
-  '@oxc-project/types@0.122.0':
-    resolution: {integrity: sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==}
-
   '@oxc-project/types@0.124.0':
     resolution: {integrity: sha512-VBFWMTBvHxS11Z5Lvlr3IWgrwhMTXV+Md+EQF0Xf60+wAdsGFTBx7X7K/hP4pi8N7dcm1RvcHwDxZ16Qx8keUg==}
+
+  '@oxc-project/types@0.127.0':
+    resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
 
   '@oxfmt/binding-android-arm-eabi@0.45.0':
     resolution: {integrity: sha512-A/UMxFob1fefCuMeGxQBulGfFE38g2Gm23ynr3u6b+b7fY7/ajGbNsa3ikMIkGMLJW/TRoQaMoP1kME7S+815w==}
@@ -344,106 +417,111 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-s70pVGhw4zqGeFnXWvAzJDlvxhlRollagdCCKRgOsgUOH3N1l0LIxf83AtGzmb5SiVM4Hjl5HyarMRfdfj3DaQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [android]
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==}
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-4ksWc9n0mhlZpZ9PMZgTGjeOPRu8MB1Z3Tz0Mo02eWfWCHMW1zN82Qz/pL/rC+yQa+8ZnutMF0JjJe7PjwasYw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [darwin]
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==}
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-SUSDOI6WwUVNcWxd02QEBjLdY1VPHvlEkw6T/8nYG322iYWCTxRb1vzk4E+mWWYehTp7ERibq54LSJGjmouOsw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [darwin]
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
-    resolution: {integrity: sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==}
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
+    resolution: {integrity: sha512-hwnz3nw9dbJ05EDO/PvcjaaewqqDy7Y1rn1UO81l8iIK1GjenME75dl16ajbvSSMfv66WXSRCYKIqfgq2KCfxw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [freebsd]
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
-    resolution: {integrity: sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==}
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
+    resolution: {integrity: sha512-IS+W7epTcwANmFSQFrS1SivEXHtl1JtuQA9wlxrZTcNi6mx+FDOYrakGevvvTwgj2JvWiK8B29/qD9BELZPyXQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm]
     os: [linux]
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==}
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-e6usGaHKW5BMNZOymS1UcEYGowQMWcgZ71Z17Sl/h2+ZziNJ1a9n3Zvcz6LdRyIW5572wBCTH/Z+bKuZouGk9Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==}
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-b/CgbwAJpmrRLp02RPfhbudf5tZnN9nsPWK82znefso832etkem8H7FSZwxrOI9djcdTP7U6YfNhbRnh7djErg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==}
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-4EII1iNGRUN5WwGbF/kOh/EIkoDN9HsupgLQoXfY+D1oyJm7/F4t5PYU5n8SWZgG0FEwakyM8pGgwcBYruGTlA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==}
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-AH8oq3XqQo4IibpVXvPeLDI5pzkpYn0WiZAfT05kFzoJ6tQNzwRdDYQ45M8I/gslbodRZwW8uxLhbSBbkv96rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
-    resolution: {integrity: sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==}
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
+    resolution: {integrity: sha512-cLnjV3xfo7KslbU41Z7z8BH/E1y5mzUYzAqih1d1MDaIGZRCMqTijqLv76/P7fyHuvUcfGsIpqCdddbxLLK9rA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
-    resolution: {integrity: sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==}
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
+    resolution: {integrity: sha512-0phclDw1spsL7dUB37sIARuis2tAgomCJXAHZlpt8PXZ4Ba0dRP1e+66lsRqrfhISeN9bEGNjQs+T/Fbd7oYGw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
-    resolution: {integrity: sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==}
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
+    resolution: {integrity: sha512-0ag/hEgXOwgw4t8QyQvUCxvEg+V0KBcA6YuOx9g0r02MprutRF5dyljgm3EmR02O292UX7UeS6HzWHAl6KgyhA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [openharmony]
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12':
-    resolution: {integrity: sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==}
-    engines: {node: '>=14.0.0'}
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
+    resolution: {integrity: sha512-LEXei6vo0E5wTGwpkJ4KoT3OZJRnglwldt5ziLzOlc6qqb55z4tWNq2A+PFqCJuvWWdP53CVhG1Z9NtToDPJrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [wasm32]
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==}
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-gUmyzBl3SPMa6hrqFUth9sVfcLBlYsbMzBx5PlexMroZStgzGqlZ26pYG89rBb45Mnia+oil6YAIFeEWGWhoZA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [win32]
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
-    resolution: {integrity: sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==}
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
+    resolution: {integrity: sha512-3hkiolcUAvPB9FLb3UZdfjVVNWherN1f/skkGWJP/fgSQhYUZpSIRr0/I8ZK9TkF3F7kxvJAk0+IcKvPHk9qQg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
 
-  '@rolldown/pluginutils@1.0.0-rc.12':
-    resolution: {integrity: sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==}
+  '@rolldown/pluginutils@1.0.0-rc.17':
+    resolution: {integrity: sha512-n8iosDOt6Ig1UhJ2AYqoIhHWh/isz0xpicHTzpKBeotdVsTEcxsSA/i3EVM7gQAj0rU27OLAxCjzlj15IWY7bg==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -653,12 +731,18 @@ packages:
     resolution: {integrity: sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==}
     engines: {node: '>=20.18.1'}
 
+  codemirror@6.0.2:
+    resolution: {integrity: sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==}
+
   commander@14.0.3:
     resolution: {integrity: sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==}
     engines: {node: '>=20'}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  crelt@1.0.6:
+    resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
 
   css-select@5.2.2:
     resolution: {integrity: sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==}
@@ -724,6 +808,11 @@ packages:
     peerDependenciesMeta:
       picomatch:
         optional: true
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -874,6 +963,16 @@ packages:
     resolution: {integrity: sha512-1wrVzJ2STrpmONHKBy228LM1b84msXDUoAzVEl0R8Mz4Ce6EPr+IVtxm8+yvrqLYMHswREkjYFaMxnyGnaY3Ng==}
     hasBin: true
 
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   pngjs@7.0.0:
     resolution: {integrity: sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==}
     engines: {node: '>=14.19.0'}
@@ -882,8 +981,8 @@ packages:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  rolldown@1.0.0-rc.12:
-    resolution: {integrity: sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==}
+  rolldown@1.0.0-rc.17:
+    resolution: {integrity: sha512-ZrT53oAKrtA4+YtBWPQbtPOxIbVDbxT0orcYERKd63VJTF13zPcgXTvD4843L8pcsI7M6MErt8QtON6lrB9tyA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
@@ -909,6 +1008,9 @@ packages:
 
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
+
+  style-mod@4.1.3:
+    resolution: {integrity: sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -953,14 +1055,14 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  vite@8.0.3:
-    resolution: {integrity: sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==}
+  vite@8.0.10:
+    resolution: {integrity: sha512-rZuUu9j6J5uotLDs+cAA4O5H4K1SfPliUlQwqa6YEwSrWDZzP4rhm00oJR5snMewjxF5V/K3D4kctsUTsIU9Mw==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
       '@vitejs/devtools': ^0.1.0
-      esbuild: ^0.27.0
+      esbuild: ^0.27.0 || ^0.28.0
       jiti: '>=1.21.0'
       less: ^4.0.0
       sass: ^1.70.0
@@ -1037,6 +1139,9 @@ packages:
       jsdom:
         optional: true
 
+  w3c-keyname@2.2.8:
+    resolution: {integrity: sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==}
+
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
@@ -1065,36 +1170,119 @@ packages:
 
 snapshots:
 
-  '@emnapi/core@1.9.1':
+  '@codemirror/autocomplete@6.20.1':
     dependencies:
-      '@emnapi/wasi-threads': 1.2.0
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/commands@6.10.3':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+
+  '@codemirror/lang-css@6.3.1':
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/language': 6.12.3
+      '@codemirror/state': 6.6.0
+      '@lezer/common': 1.5.2
+      '@lezer/css': 1.3.3
+
+  '@codemirror/lang-json@6.0.2':
+    dependencies:
+      '@codemirror/language': 6.12.3
+      '@lezer/json': 1.0.3
+
+  '@codemirror/language@6.12.3':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+      style-mod: 4.1.3
+
+  '@codemirror/lint@6.9.5':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
+
+  '@codemirror/search@6.7.0':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+      crelt: 1.0.6
+
+  '@codemirror/state@6.6.0':
+    dependencies:
+      '@marijn/find-cluster-break': 1.0.2
+
+  '@codemirror/view@6.41.1':
+    dependencies:
+      '@codemirror/state': 6.6.0
+      crelt: 1.0.6
+      style-mod: 4.1.3
+      w3c-keyname: 2.2.8
+
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/runtime@1.9.1':
+  '@emnapi/runtime@1.10.0':
     dependencies:
       tslib: 2.8.1
     optional: true
 
-  '@emnapi/wasi-threads@1.2.0':
+  '@emnapi/wasi-threads@1.2.1':
     dependencies:
       tslib: 2.8.1
     optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@lezer/common@1.5.2': {}
+
+  '@lezer/css@1.3.3':
     dependencies:
-      '@emnapi/core': 1.9.1
-      '@emnapi/runtime': 1.9.1
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/highlight@1.2.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@lezer/json@1.0.3':
+    dependencies:
+      '@lezer/common': 1.5.2
+      '@lezer/highlight': 1.2.3
+      '@lezer/lr': 1.4.10
+
+  '@lezer/lr@1.4.10':
+    dependencies:
+      '@lezer/common': 1.5.2
+
+  '@marijn/find-cluster-break@1.0.2': {}
+
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
       '@tybys/wasm-util': 0.10.1
     optional: true
 
   '@oxc-project/runtime@0.124.0': {}
 
-  '@oxc-project/types@0.122.0': {}
-
   '@oxc-project/types@0.124.0': {}
+
+  '@oxc-project/types@0.127.0': {}
 
   '@oxfmt/binding-android-arm-eabi@0.45.0':
     optional: true
@@ -1228,59 +1416,62 @@ snapshots:
   '@oxlint/binding-win32-x64-msvc@1.60.0':
     optional: true
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@polka/url@1.0.0-next.29': {}
 
-  '@rolldown/binding-android-arm64@1.0.0-rc.12':
+  '@rolldown/binding-android-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-arm64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-darwin-x64@1.0.0-rc.12':
+  '@rolldown/binding-darwin-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-freebsd-x64@1.0.0-rc.12':
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-linux-x64-musl@1.0.0-rc.12':
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-openharmony-arm64@1.0.0-rc.12':
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-wasm32-wasi@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)':
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.17':
     dependencies:
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
-  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.12':
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.17':
     optional: true
 
-  '@rolldown/pluginutils@1.0.0-rc.12': {}
+  '@rolldown/pluginutils@1.0.0-rc.17': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -1311,13 +1502,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.4(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0))':
+  '@vitest/mocker@4.1.4(vite@8.0.10(@types/node@25.6.0))':
     dependencies:
       '@vitest/spy': 4.1.4
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)
+      vite: 8.0.10(@types/node@25.6.0)
 
   '@vitest/pretty-format@4.1.4':
     dependencies:
@@ -1372,7 +1563,7 @@ snapshots:
   '@voidzero-dev/vite-plus-linux-x64-musl@0.1.18':
     optional: true
 
-  '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0))':
+  '@voidzero-dev/vite-plus-test@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.6.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@types/chai': 5.2.3
@@ -1386,7 +1577,7 @@ snapshots:
       tinybench: 2.9.0
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)
+      vite: 8.0.10(@types/node@25.6.0)
       ws: 8.20.0
     optionalDependencies:
       '@types/node': 25.6.0
@@ -1446,9 +1637,21 @@ snapshots:
       undici: 7.25.0
       whatwg-mimetype: 4.0.0
 
+  codemirror@6.0.2:
+    dependencies:
+      '@codemirror/autocomplete': 6.20.1
+      '@codemirror/commands': 6.10.3
+      '@codemirror/language': 6.12.3
+      '@codemirror/lint': 6.9.5
+      '@codemirror/search': 6.7.0
+      '@codemirror/state': 6.6.0
+      '@codemirror/view': 6.41.1
+
   commander@14.0.3: {}
 
   convert-source-map@2.0.0: {}
+
+  crelt@1.0.6: {}
 
   css-select@5.2.2:
     dependencies:
@@ -1509,6 +1712,9 @@ snapshots:
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -1668,6 +1874,14 @@ snapshots:
     dependencies:
       pngjs: 7.0.0
 
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
+
   pngjs@7.0.0: {}
 
   postcss@8.5.10:
@@ -1676,29 +1890,26 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
-  rolldown@1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1):
+  rolldown@1.0.0-rc.17:
     dependencies:
-      '@oxc-project/types': 0.122.0
-      '@rolldown/pluginutils': 1.0.0-rc.12
+      '@oxc-project/types': 0.127.0
+      '@rolldown/pluginutils': 1.0.0-rc.17
     optionalDependencies:
-      '@rolldown/binding-android-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-arm64': 1.0.0-rc.12
-      '@rolldown/binding-darwin-x64': 1.0.0-rc.12
-      '@rolldown/binding-freebsd-x64': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.12
-      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.12
-      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.12
-      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.12
-      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
-      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.12
-      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.12
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
+      '@rolldown/binding-android-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.17
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.17
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.17
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.17
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.17
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.17
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.17
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.17
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.17
 
   safer-buffer@2.1.2: {}
 
@@ -1717,6 +1928,8 @@ snapshots:
   std-env@4.0.0: {}
 
   std-env@4.1.0: {}
+
+  style-mod@4.1.3: {}
 
   tinybench@2.9.0: {}
 
@@ -1742,11 +1955,11 @@ snapshots:
 
   undici@7.25.0: {}
 
-  vite-plus@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)):
+  vite-plus@0.1.18(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.6.0)):
     dependencies:
       '@oxc-project/types': 0.124.0
       '@voidzero-dev/vite-plus-core': 0.1.18(@types/node@25.6.0)(typescript@6.0.2)
-      '@voidzero-dev/vite-plus-test': 0.1.18(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0))
+      '@voidzero-dev/vite-plus-test': 0.1.18(@types/node@25.6.0)(typescript@6.0.2)(vite@8.0.10(@types/node@25.6.0))
       oxfmt: 0.45.0
       oxlint: 1.60.0(oxlint-tsgolint@0.20.0)
       oxlint-tsgolint: 0.20.0
@@ -1789,24 +2002,21 @@ snapshots:
       - vite
       - yaml
 
-  vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0):
+  vite@8.0.10(@types/node@25.6.0):
     dependencies:
       lightningcss: 1.32.0
       picomatch: 4.0.4
       postcss: 8.5.10
-      rolldown: 1.0.0-rc.12(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)
+      rolldown: 1.0.0-rc.17
       tinyglobby: 0.2.16
     optionalDependencies:
       '@types/node': 25.6.0
       fsevents: 2.3.3
-    transitivePeerDependencies:
-      - '@emnapi/core'
-      - '@emnapi/runtime'
 
-  vitest@4.1.4(@types/node@25.6.0)(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)):
+  vitest@4.1.4(@types/node@25.6.0)(vite@8.0.10(@types/node@25.6.0)):
     dependencies:
       '@vitest/expect': 4.1.4
-      '@vitest/mocker': 4.1.4(vite@8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0))
+      '@vitest/mocker': 4.1.4(vite@8.0.10(@types/node@25.6.0))
       '@vitest/pretty-format': 4.1.4
       '@vitest/runner': 4.1.4
       '@vitest/snapshot': 4.1.4
@@ -1823,12 +2033,14 @@ snapshots:
       tinyexec: 1.1.1
       tinyglobby: 0.2.16
       tinyrainbow: 3.1.0
-      vite: 8.0.3(@emnapi/core@1.9.1)(@emnapi/runtime@1.9.1)(@types/node@25.6.0)
+      vite: 8.0.10(@types/node@25.6.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 25.6.0
     transitivePeerDependencies:
       - msw
+
+  w3c-keyname@2.2.8: {}
 
   whatwg-encoding@3.1.1:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,3 @@
 packages:
   - "packages/*"
+  - "web"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,9 @@
     },
     {
       "path": "./packages/cli"
+    },
+    {
+      "path": "./web"
     }
   ]
 }

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,120 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      name="description"
+      content="Validate CSS custom property registrations and var() usages in the browser."
+    />
+    <title>CSS Property Type Validator</title>
+    <link rel="stylesheet" href="/src/styles.css" type="text/css" media="screen" />
+  </head>
+  <body>
+    <css-validator-controller>
+      <header class="app-header">
+        <div>
+          <p class="eyebrow">Browser validator</p>
+          <h1>CSS Property Type Validator</h1>
+          <p class="overview">
+            Paste or open a CSS file, then validate typed custom properties and var() usage locally
+            in your browser.
+            <a href="https://github.com/schalkneethling/css-property-type-validator">View repo</a>
+          </p>
+        </div>
+        <section class="header-actions" aria-labelledby="header-actions-title">
+          <h2 class="visually-hidden" id="header-actions-title">Validation actions</h2>
+          <label class="file-button" for="css-file-input">
+            <span>Open CSS</span>
+            <input id="css-file-input" class="js-file-input" type="file" accept=".css,text/css" />
+          </label>
+          <button class="primary-action js-validate-button" type="button">Validate</button>
+        </section>
+      </header>
+
+      <main class="app-shell">
+        <article class="workspace" aria-labelledby="workspace-title">
+          <h2 class="visually-hidden" id="workspace-title">Validator workspace</h2>
+          <section class="panel input-panel" aria-labelledby="input-title">
+            <div class="panel-header">
+              <div>
+                <p class="panel-kicker">Input</p>
+                <h2 id="input-title">CSS source</h2>
+              </div>
+              <span class="file-chip js-file-name">pasted.css</span>
+            </div>
+            <div class="validation-status js-validation-status" hidden></div>
+            <validator-code-editor
+              class="editor input-editor js-input-editor"
+              label="CSS input"
+              language="css"
+            ></validator-code-editor>
+          </section>
+
+          <section class="panel output-panel" aria-labelledby="output-title">
+            <div class="panel-header output-header">
+              <div>
+                <p class="panel-kicker">Output</p>
+                <h2 id="output-title">Validation result</h2>
+              </div>
+              <fieldset class="format-toggle">
+                <legend>Output format</legend>
+                <label for="output-format-human">
+                  <input
+                    id="output-format-human"
+                    class="js-output-format"
+                    type="radio"
+                    name="output-format"
+                    value="human"
+                    checked
+                  />
+                  <span>Human</span>
+                </label>
+                <label for="output-format-json">
+                  <input
+                    id="output-format-json"
+                    class="js-output-format"
+                    type="radio"
+                    name="output-format"
+                    value="json"
+                  />
+                  <span>JSON</span>
+                </label>
+              </fieldset>
+            </div>
+
+            <validator-code-editor
+              class="editor output-editor js-output-editor"
+              label="Validation output"
+              language="text"
+              readonly
+            ></validator-code-editor>
+
+            <section aria-labelledby="validation-summary-title">
+              <h3 class="visually-hidden" id="validation-summary-title">Validation summary</h3>
+              <dl class="result-stats" aria-live="polite">
+                <div>
+                  <dt>Diagnostics</dt>
+                  <dd class="js-stat-diagnostics">—</dd>
+                </div>
+                <div>
+                  <dt>Registered</dt>
+                  <dd class="js-stat-registered">—</dd>
+                </div>
+                <div>
+                  <dt>Validated</dt>
+                  <dd class="js-stat-validated">—</dd>
+                </div>
+                <div>
+                  <dt>Skipped</dt>
+                  <dd class="js-stat-skipped">—</dd>
+                </div>
+              </dl>
+            </section>
+          </section>
+        </article>
+      </main>
+    </css-validator-controller>
+    <script type="module" src="/src/main.ts"></script>
+  </body>
+</html>

--- a/web/package.json
+++ b/web/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@schalkneethling/css-property-type-validator-web",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Browser UI for CSS Property Type Validator.",
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json && vite build",
+    "dev": "vite",
+    "preview": "vite preview",
+    "test:e2e": "playwright test",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@codemirror/lang-css": "6.3.1",
+    "@codemirror/lang-json": "6.0.2",
+    "@codemirror/state": "6.6.0",
+    "@codemirror/view": "6.41.1",
+    "@schalkneethling/css-property-type-validator-core": "workspace:*",
+    "codemirror": "6.0.2",
+    "vite": "8.0.10"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.59.1"
+  }
+}

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./tests/e2e",
+  testMatch: "**/*.e2e.ts",
+  webServer: {
+    command: "pnpm run dev -- --host 127.0.0.1 --port 4177",
+    url: "http://127.0.0.1:4177",
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+  use: {
+    baseURL: "http://127.0.0.1:4177",
+    trace: "on-first-retry",
+  },
+  projects: [
+    {
+      name: "chromium",
+      use: { ...devices["Desktop Chrome"] },
+    },
+  ],
+});

--- a/web/src/components/code-editor.ts
+++ b/web/src/components/code-editor.ts
@@ -1,0 +1,168 @@
+import { css as cssLanguage } from "@codemirror/lang-css";
+import { json as jsonLanguage } from "@codemirror/lang-json";
+import { EditorState, type Extension } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { basicSetup } from "codemirror";
+
+type EditorLanguage = "css" | "json" | "text";
+
+function languageExtension(language: EditorLanguage): Extension[] {
+  if (language === "css") {
+    return [cssLanguage()];
+  }
+
+  if (language === "json") {
+    return [jsonLanguage()];
+  }
+
+  return [];
+}
+
+function toEditorLanguage(value: string | null): EditorLanguage {
+  if (value === "css" || value === "json") {
+    return value;
+  }
+
+  return "text";
+}
+
+export class ValidatorCodeEditor extends HTMLElement {
+  static observedAttributes = ["label", "language", "readonly"];
+
+  #editorView: EditorView | null = null;
+  #host: HTMLDivElement | null = null;
+  #label = "Editor";
+  #language: EditorLanguage = "text";
+  #readonly = false;
+  #value = "";
+
+  get label(): string {
+    return this.#label;
+  }
+
+  set label(value: string) {
+    this.#label = value;
+    this.#createEditor();
+  }
+
+  get language(): EditorLanguage {
+    return this.#language;
+  }
+
+  set language(value: EditorLanguage) {
+    this.#language = value;
+    this.#createEditor();
+  }
+
+  get readonly(): boolean {
+    return this.#readonly;
+  }
+
+  set readonly(value: boolean) {
+    this.#readonly = value;
+    this.#createEditor();
+  }
+
+  get value(): string {
+    return this.#value;
+  }
+
+  set value(value: string) {
+    this.#value = value;
+    this.#syncEditorValue();
+  }
+
+  connectedCallback(): void {
+    this.#label = this.getAttribute("label") ?? this.#label;
+    this.#language = toEditorLanguage(this.getAttribute("language"));
+    this.#readonly = this.hasAttribute("readonly");
+    this.#host = document.createElement("div");
+    this.#host.className = "code-editor-host";
+    this.replaceChildren(this.#host);
+    this.#createEditor();
+  }
+
+  disconnectedCallback(): void {
+    this.#editorView?.destroy();
+    this.#editorView = null;
+    this.#host = null;
+  }
+
+  attributeChangedCallback(name: string, _oldValue: string | null, newValue: string | null): void {
+    if (name === "label") {
+      this.label = newValue ?? "Editor";
+      return;
+    }
+
+    if (name === "language") {
+      this.language = toEditorLanguage(newValue);
+      return;
+    }
+
+    if (name === "readonly") {
+      this.readonly = newValue !== null;
+    }
+  }
+
+  #createEditor(): void {
+    if (!this.#host) {
+      return;
+    }
+
+    this.#editorView?.destroy();
+
+    const extensions: Extension[] = [
+      basicSetup,
+      EditorView.lineWrapping,
+      EditorView.contentAttributes.of({
+        "aria-label": this.#label,
+        role: "textbox",
+      }),
+      EditorView.updateListener.of((update) => {
+        if (!update.docChanged || this.#readonly) {
+          return;
+        }
+
+        this.#value = update.state.doc.toString();
+        this.dispatchEvent(
+          new CustomEvent<string>("editor-change", {
+            bubbles: true,
+            composed: true,
+            detail: this.#value,
+          }),
+        );
+      }),
+      ...languageExtension(this.#language),
+    ];
+
+    if (this.#readonly) {
+      extensions.push(EditorState.readOnly.of(true), EditorView.editable.of(false));
+    }
+
+    this.#editorView = new EditorView({
+      doc: this.#value,
+      extensions,
+      parent: this.#host,
+    });
+  }
+
+  #syncEditorValue(): void {
+    const currentValue = this.#editorView?.state.doc.toString();
+
+    if (!this.#editorView || currentValue === undefined || this.#value === currentValue) {
+      return;
+    }
+
+    this.#editorView.dispatch({
+      changes: {
+        from: 0,
+        to: currentValue.length,
+        insert: this.#value,
+      },
+    });
+  }
+}
+
+if (!customElements.get("validator-code-editor")) {
+  customElements.define("validator-code-editor", ValidatorCodeEditor);
+}

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,0 +1,208 @@
+import {
+  formatValidationResult,
+  validateFiles,
+  type OutputFormat,
+  type ValidationResult,
+} from "@schalkneethling/css-property-type-validator-core";
+
+import "./components/code-editor.js";
+
+const DEFAULT_CSS = `@property --brand-color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: transparent;
+}
+
+.card {
+  inline-size: var(--brand-color);
+}`;
+
+const INITIAL_OUTPUT = "Run validation to see diagnostics here.";
+
+interface CodeEditorElement extends HTMLElement {
+  language: "css" | "json" | "text";
+  value: string;
+}
+
+function queryElement<T extends Element>(root: ParentNode, selector: string): T {
+  const element = root.querySelector<T>(selector);
+
+  if (!element) {
+    throw new Error(`Missing required element: ${selector}`);
+  }
+
+  return element;
+}
+
+function requireCachedValue<T>(value: T | null, name: string): T {
+  if (!value) {
+    throw new Error(`Missing cached element: ${name}`);
+  }
+
+  return value;
+}
+
+class ValidatorController extends HTMLElement {
+  #cssSource = DEFAULT_CSS;
+  #fileName = "pasted.css";
+  #outputFormat: OutputFormat = "human";
+  #result: ValidationResult | null = null;
+
+  #abortController: AbortController | null = null;
+  #fileInput: HTMLInputElement | null = null;
+  #fileNameElement: HTMLElement | null = null;
+  #inputEditor: CodeEditorElement | null = null;
+  #outputEditor: CodeEditorElement | null = null;
+  #outputFormatInputs: HTMLInputElement[] = [];
+  #statDiagnostics: HTMLElement | null = null;
+  #statRegistered: HTMLElement | null = null;
+  #statSkipped: HTMLElement | null = null;
+  #statValidated: HTMLElement | null = null;
+  #validationStatus: HTMLElement | null = null;
+  #validateButton: HTMLButtonElement | null = null;
+
+  connectedCallback(): void {
+    this.#abortController = new AbortController();
+    this.#cacheDOMElements();
+    this.#initializeDOM();
+    this.#addEventListeners();
+  }
+
+  disconnectedCallback(): void {
+    this.#abortController?.abort();
+    this.#abortController = null;
+  }
+
+  #cacheDOMElements(): void {
+    this.#fileInput = queryElement<HTMLInputElement>(this, ".js-file-input");
+    this.#fileNameElement = queryElement<HTMLElement>(this, ".js-file-name");
+    this.#inputEditor = queryElement<CodeEditorElement>(this, ".js-input-editor");
+    this.#outputEditor = queryElement<CodeEditorElement>(this, ".js-output-editor");
+    this.#outputFormatInputs = Array.from(
+      this.querySelectorAll<HTMLInputElement>(".js-output-format"),
+    );
+    this.#statDiagnostics = queryElement<HTMLElement>(this, ".js-stat-diagnostics");
+    this.#statRegistered = queryElement<HTMLElement>(this, ".js-stat-registered");
+    this.#statSkipped = queryElement<HTMLElement>(this, ".js-stat-skipped");
+    this.#statValidated = queryElement<HTMLElement>(this, ".js-stat-validated");
+    this.#validationStatus = queryElement<HTMLElement>(this, ".js-validation-status");
+    this.#validateButton = queryElement<HTMLButtonElement>(this, ".js-validate-button");
+  }
+
+  #initializeDOM(): void {
+    const inputEditor = requireCachedValue(this.#inputEditor, "input editor");
+    const outputEditor = requireCachedValue(this.#outputEditor, "output editor");
+    const fileNameElement = requireCachedValue(this.#fileNameElement, "file name");
+
+    inputEditor.value = this.#cssSource;
+    outputEditor.value = INITIAL_OUTPUT;
+    fileNameElement.textContent = this.#fileName;
+  }
+
+  #addEventListeners(): void {
+    const abortController = requireCachedValue(this.#abortController, "abort controller");
+    const fileInput = requireCachedValue(this.#fileInput, "file input");
+    const inputEditor = requireCachedValue(this.#inputEditor, "input editor");
+    const validateButton = requireCachedValue(this.#validateButton, "validate button");
+    const { signal } = abortController;
+
+    fileInput.addEventListener("change", this.#handleFileSelection, { signal });
+    inputEditor.addEventListener("editor-change", this.#handleEditorChange, { signal });
+    validateButton.addEventListener("click", this.#validateCss, { signal });
+
+    for (const input of this.#outputFormatInputs) {
+      input.addEventListener("change", this.#handleFormatChange, { signal });
+    }
+  }
+
+  #handleEditorChange = (event: Event): void => {
+    this.#cssSource = (event as CustomEvent<string>).detail;
+
+    if (!this.#fileName) {
+      this.#fileName = "pasted.css";
+    }
+  };
+
+  #handleFileSelection = async (event: Event): Promise<void> => {
+    const input = event.currentTarget as HTMLInputElement;
+    const [file] = Array.from(input.files ?? []);
+
+    if (!file) {
+      return;
+    }
+
+    this.#cssSource = await file.text();
+    this.#fileName = file.name;
+    requireCachedValue(this.#inputEditor, "input editor").value = this.#cssSource;
+    requireCachedValue(this.#fileNameElement, "file name").textContent = this.#fileName;
+    input.value = "";
+  };
+
+  #handleFormatChange = (event: Event): void => {
+    const input = event.currentTarget as HTMLInputElement;
+
+    this.#outputFormat = input.value === "json" ? "json" : "human";
+    this.#renderOutput();
+  };
+
+  #validateCss = (): void => {
+    this.#result = validateFiles([
+      {
+        path: this.#fileName || "pasted.css",
+        css: this.#cssSource,
+      },
+    ]);
+    this.#renderOutput();
+    this.#renderStatus();
+    this.#renderStats();
+  };
+
+  #renderOutput(): void {
+    const outputEditor = requireCachedValue(this.#outputEditor, "output editor");
+
+    outputEditor.language = this.#outputFormat === "json" ? "json" : "text";
+    outputEditor.value = this.#result
+      ? formatValidationResult(this.#result, this.#outputFormat)
+      : INITIAL_OUTPUT;
+  }
+
+  #renderStats(): void {
+    const statDiagnostics = requireCachedValue(this.#statDiagnostics, "diagnostics stat");
+    const statRegistered = requireCachedValue(this.#statRegistered, "registered stat");
+    const statSkipped = requireCachedValue(this.#statSkipped, "skipped stat");
+    const statValidated = requireCachedValue(this.#statValidated, "validated stat");
+
+    statDiagnostics.textContent = String(this.#result?.diagnostics.length ?? "—");
+    statRegistered.textContent = String(this.#result?.registry.length ?? "—");
+    statSkipped.textContent = String(this.#result?.skippedDeclarations ?? "—");
+    statValidated.textContent = String(this.#result?.validatedDeclarations ?? "—");
+  }
+
+  #renderStatus(): void {
+    const validationStatus = requireCachedValue(this.#validationStatus, "validation status");
+    const hasPassed = Boolean(this.#result && this.#result.diagnostics.length === 0);
+
+    validationStatus.replaceChildren();
+    validationStatus.hidden = !hasPassed;
+
+    if (!hasPassed) {
+      return;
+    }
+
+    const message = document.createElement("div");
+    const heading = document.createElement("strong");
+    const detail = document.createElement("span");
+
+    message.className = "success-message";
+    message.role = "status";
+    heading.textContent = "No validation issues found.";
+    detail.textContent = "Your registered custom properties matched the checked declarations.";
+
+    message.append(heading, detail);
+    validationStatus.append(message);
+  }
+}
+
+if (!customElements.get("css-validator-controller")) {
+  customElements.define("css-validator-controller", ValidatorController);
+}

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -1,0 +1,877 @@
+@property --color-accent {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #f3b56d;
+}
+
+@property --color-accent-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #f0b86b;
+}
+
+@property --color-body {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #d8d2c2;
+}
+
+@property --color-editor {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #fffaf0;
+}
+
+@property --color-editor-gutter {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #eee9dc;
+}
+
+@property --color-editor-output {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #fdf8ed;
+}
+
+@property --color-editor-text {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #212821;
+}
+
+@property --color-focus {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #69b7bc;
+}
+
+@property --color-header {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #1f251f;
+}
+
+@property --color-header-border {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(248 243 231 / 0.18);
+}
+
+@property --color-header-control {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(248 243 231 / 0.08);
+}
+
+@property --color-header-control-border {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(248 243 231 / 0.25);
+}
+
+@property --color-header-rgb {
+  syntax: "*";
+  inherits: true;
+  initial-value: 31 37 31;
+}
+
+@property --color-heading {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #202820;
+}
+
+@property --color-link {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #0b5f68;
+}
+
+@property --color-link-hover {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #073f45;
+}
+
+@property --color-link-underline {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(11 95 104 / 0.35);
+}
+
+@property --color-page {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #e7e3d8;
+}
+
+@property --color-page-grid-block {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(31 37 31 / 0.05);
+}
+
+@property --color-page-grid-inline {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(31 37 31 / 0.06);
+}
+
+@property --color-panel {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #f8f3e7;
+}
+
+@property --color-panel-border {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(31 37 31 / 0.2);
+}
+
+@property --color-panel-divider {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(31 37 31 / 0.16);
+}
+
+@property --color-panel-kicker {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #a35622;
+}
+
+@property --color-panel-rule {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(31 37 31 / 0.12);
+}
+
+@property --color-pill-border {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(31 37 31 / 0.14);
+}
+
+@property --color-success {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #dcebc9;
+}
+
+@property --color-success-border {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: rgb(22 57 34 / 0.18);
+}
+
+@property --color-success-ink {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #163922;
+}
+
+@property --color-success-muted {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #35543d;
+}
+
+@property --color-text {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #1f251f;
+}
+
+@property --color-toggle-text {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #4f594e;
+}
+
+@property --color-ui-muted {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #697267;
+}
+
+@property --color-ui-muted-strong {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #384238;
+}
+
+@property --color-ui-subtle {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: #788073;
+}
+
+@property --font-body {
+  syntax: "*";
+  inherits: true;
+  initial-value: 400 0.98rem / 1.5 system-ui;
+}
+
+@property --font-caption {
+  syntax: "*";
+  inherits: true;
+  initial-value: 600 0.72rem / 1 system-ui;
+}
+
+@property --font-caption-strong {
+  syntax: "*";
+  inherits: true;
+  initial-value: 800 0.72rem / 1 system-ui;
+}
+
+@property --font-chip {
+  syntax: "*";
+  inherits: true;
+  initial-value: 400 0.78rem / 1.5 monospace;
+}
+
+@property --font-control {
+  syntax: "*";
+  inherits: true;
+  initial-value: 600 0.82rem / 1.5 system-ui;
+}
+
+@property --font-editor {
+  syntax: "*";
+  inherits: true;
+  initial-value: 400 0.9rem / 1.55 monospace;
+}
+
+@property --font-family-body {
+  syntax: "*";
+  inherits: true;
+  initial-value: system-ui;
+}
+
+@property --font-family-display {
+  syntax: "*";
+  inherits: true;
+  initial-value: serif;
+}
+
+@property --font-family-mono {
+  syntax: "*";
+  inherits: true;
+  initial-value: monospace;
+}
+
+@property --font-heading-page {
+  syntax: "*";
+  inherits: true;
+  initial-value: 700 2rem / 0.92 serif;
+}
+
+@property --font-heading-panel {
+  syntax: "*";
+  inherits: true;
+  initial-value: 700 1.15rem / 1 serif;
+}
+
+@property --font-link {
+  syntax: "*";
+  inherits: true;
+  initial-value: 700 0.98rem / 1.5 system-ui;
+}
+
+@property --font-size-body {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 15.68px;
+}
+
+@property --font-size-caption {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 11.52px;
+}
+
+@property --font-size-chip {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 12.48px;
+}
+
+@property --font-size-control {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 13.12px;
+}
+
+@property --font-size-editor {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 14.4px;
+}
+
+@property --font-size-heading-page {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 32px;
+}
+
+@property --font-size-heading-panel {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 18.4px;
+}
+
+@property --font-size-stat {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 23.2px;
+}
+
+@property --font-size-success {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 15.2px;
+}
+
+@property --font-size-success-detail {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 14.08px;
+}
+
+@property --font-stat {
+  syntax: "*";
+  inherits: true;
+  initial-value: 700 1.45rem / 1 serif;
+}
+
+@property --font-success {
+  syntax: "*";
+  inherits: true;
+  initial-value: 700 0.95rem / 1.5 system-ui;
+}
+
+@property --font-success-detail {
+  syntax: "*";
+  inherits: true;
+  initial-value: 400 0.88rem / 1.5 system-ui;
+}
+
+@property --line-height-body {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 1.5;
+}
+
+@property --line-height-editor {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 1.55;
+}
+
+@property --line-height-tight {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 1;
+}
+
+@property --line-height-title {
+  syntax: "<number>";
+  inherits: true;
+  initial-value: 0.92;
+}
+
+:root {
+  --color-accent: #f3b56d;
+  --color-accent-strong: #f0b86b;
+  --color-body: #d8d2c2;
+  --color-editor: #fffaf0;
+  --color-editor-gutter: #eee9dc;
+  --color-editor-output: #fdf8ed;
+  --color-editor-text: #212821;
+  --color-focus: #69b7bc;
+  --color-header: #1f251f;
+  --color-header-border: rgb(248 243 231 / 0.18);
+  --color-header-control: rgb(248 243 231 / 0.08);
+  --color-header-control-border: rgb(248 243 231 / 0.25);
+  --color-header-rgb: 31 37 31;
+  --color-heading: #202820;
+  --color-link: #0b5f68;
+  --color-link-hover: #073f45;
+  --color-link-underline: rgb(11 95 104 / 0.35);
+  --color-page: #e7e3d8;
+  --color-page-grid-block: rgb(31 37 31 / 0.05);
+  --color-page-grid-inline: rgb(31 37 31 / 0.06);
+  --color-panel: #f8f3e7;
+  --color-panel-border: rgb(31 37 31 / 0.2);
+  --color-panel-divider: rgb(31 37 31 / 0.16);
+  --color-panel-kicker: #a35622;
+  --color-panel-rule: rgb(31 37 31 / 0.12);
+  --color-pill-border: rgb(31 37 31 / 0.14);
+  --color-success: #dcebc9;
+  --color-success-border: rgb(22 57 34 / 0.18);
+  --color-success-ink: #163922;
+  --color-success-muted: #35543d;
+  --color-text: #1f251f;
+  --color-toggle-text: #4f594e;
+  --color-ui-muted: #697267;
+  --color-ui-muted-strong: #384238;
+  --color-ui-subtle: #788073;
+
+  --font-body: 400 var(--font-size-body) / var(--line-height-body) var(--font-family-body);
+  --font-caption: 600 var(--font-size-caption) / var(--line-height-tight) var(--font-family-body);
+  --font-caption-strong: 800 var(--font-size-caption) / var(--line-height-tight)
+    var(--font-family-body);
+  --font-chip: 400 var(--font-size-chip) / var(--line-height-body) var(--font-family-mono);
+  --font-control: 600 var(--font-size-control) / var(--line-height-body) var(--font-family-body);
+  --font-editor: 400 var(--font-size-editor) / var(--line-height-editor) var(--font-family-mono);
+  --font-family-body: "Avenir Next", "Segoe UI", "Helvetica Neue", sans-serif;
+  --font-family-display: Georgia, "Times New Roman", serif;
+  --font-family-mono: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+  --font-heading-page: 700 var(--font-size-heading-page) / var(--line-height-title)
+    var(--font-family-display);
+  --font-heading-panel: 700 var(--font-size-heading-panel) / var(--line-height-tight)
+    var(--font-family-display);
+  --font-link: 700 var(--font-size-body) / var(--line-height-body) var(--font-family-body);
+  --font-size-body: 0.98rem;
+  --font-size-caption: 0.72rem;
+  --font-size-chip: 0.78rem;
+  --font-size-control: 0.82rem;
+  --font-size-editor: 0.9rem;
+  --font-size-heading-page: clamp(2rem, 5vw, 4.5rem);
+  --font-size-heading-panel: clamp(1.15rem, 2vw, 1.65rem);
+  --font-size-stat: 1.45rem;
+  --font-size-success: 0.95rem;
+  --font-size-success-detail: 0.88rem;
+  --font-stat: 700 var(--font-size-stat) / var(--line-height-tight) var(--font-family-display);
+  --font-success: 700 var(--font-size-success) / var(--line-height-body) var(--font-family-body);
+  --font-success-detail: 400 var(--font-size-success-detail) / var(--line-height-body)
+    var(--font-family-body);
+  --line-height-body: 1.5;
+  --line-height-editor: 1.55;
+  --line-height-tight: 1;
+  --line-height-title: 0.92;
+
+  background: var(--color-page);
+  color: var(--color-text);
+  font: var(--font-body);
+  font-synthesis: none;
+  text-rendering: optimizeLegibility;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  min-inline-size: 20rem;
+  min-block-size: 100svb;
+  margin: 0;
+  background:
+    linear-gradient(90deg, var(--color-page-grid-inline) 0.0625rem, transparent 0.0625rem),
+    linear-gradient(0deg, var(--color-page-grid-block) 0.0625rem, transparent 0.0625rem),
+    var(--color-page);
+  background-size: 1.5rem 1.5rem;
+}
+
+css-validator-controller {
+  display: block;
+  min-block-size: 100svb;
+}
+
+button,
+input {
+  font: inherit;
+}
+
+button {
+  cursor: pointer;
+}
+
+.visually-hidden {
+  position: absolute;
+  inline-size: 0.0625rem;
+  block-size: 0.0625rem;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+}
+
+a {
+  color: var(--color-link);
+  font: var(--font-link);
+  text-decoration-color: var(--color-link-underline);
+  text-underline-offset: 0.2em;
+}
+
+a:hover {
+  color: var(--color-link-hover);
+}
+
+.app-shell {
+  display: grid;
+  min-block-size: 0;
+  padding-block: clamp(1rem, 2vw, 1.5rem);
+  padding-inline: clamp(1rem, 2vw, 1.5rem);
+}
+
+.app-header {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: end;
+  gap: 1.5rem;
+  margin-block: clamp(1rem, 2vw, 1.5rem) 0;
+  margin-inline: clamp(1rem, 2vw, 1.5rem);
+  padding-block: clamp(1rem, 2vw, 1.5rem);
+  padding-inline: clamp(1rem, 2vw, 1.5rem);
+  color: var(--color-panel);
+  background: var(--color-header);
+  border: 0.0625rem solid var(--color-header-border);
+  box-shadow: 0 1.125rem 3.75rem rgb(var(--color-header-rgb) / 0.24);
+}
+
+.eyebrow,
+.panel-kicker {
+  margin-block: 0 0.35rem;
+  margin-inline: 0;
+  color: var(--color-accent-strong);
+  font: var(--font-caption);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.panel-kicker {
+  color: var(--color-panel-kicker);
+  font: var(--font-caption);
+}
+
+h1,
+h2 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+h1 {
+  max-inline-size: 16ch;
+  font: var(--font-heading-page);
+}
+
+h2 {
+  color: var(--color-heading);
+  font: var(--font-heading-panel);
+}
+
+.overview {
+  max-inline-size: 68ch;
+  margin-block: 0.85rem 0;
+  margin-inline: 0;
+  color: var(--color-body);
+  font: var(--font-body);
+}
+
+.app-header a {
+  color: var(--color-accent);
+}
+
+.header-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 0.6rem;
+}
+
+.file-button,
+.primary-action {
+  display: inline-grid;
+  min-block-size: 2.6rem;
+  place-items: center;
+  border: 0.0625rem solid var(--color-header-control-border);
+  border-radius: 0.25rem;
+  padding-block: 0;
+  padding-inline: 1rem;
+  font: var(--font-control);
+  letter-spacing: 0.01em;
+}
+
+.file-button {
+  position: relative;
+  overflow: hidden;
+  color: var(--color-panel);
+  background: var(--color-header-control);
+}
+
+.file-button input {
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  cursor: pointer;
+}
+
+.primary-action {
+  color: var(--color-header);
+  background: var(--color-accent);
+  border-color: var(--color-accent);
+}
+
+.file-button:hover,
+.primary-action:hover {
+  translate: 0 -0.0625rem;
+}
+
+.file-button:focus-within,
+.primary-action:focus-visible,
+.format-toggle input:focus-visible + span {
+  outline: 0.1875rem solid var(--color-focus);
+  outline-offset: 0.1875rem;
+}
+
+.workspace {
+  display: grid;
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  gap: 1rem;
+  min-block-size: 0;
+}
+
+.panel {
+  display: grid;
+  grid-template-rows: auto minmax(20rem, 1fr) auto;
+  min-inline-size: 0;
+  min-block-size: 0;
+  background: var(--color-panel);
+  border: 0.0625rem solid var(--color-panel-border);
+  box-shadow: 0 0.625rem 1.875rem rgb(var(--color-header-rgb) / 0.12);
+}
+
+.panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  min-block-size: 5.75rem;
+  padding-block: 1rem;
+  padding-inline: 1rem;
+  border-block-end: 0.0625rem solid var(--color-panel-divider);
+}
+
+.input-panel {
+  grid-template-rows: auto auto minmax(20rem, 1fr);
+}
+
+.validation-status {
+  min-block-size: 0;
+}
+
+.file-chip {
+  overflow: hidden;
+  max-inline-size: min(22rem, 45vw);
+  padding-block: 0.3rem;
+  padding-inline: 0.55rem;
+  color: var(--color-ui-muted-strong);
+  background: var(--color-page);
+  border: 0.0625rem solid var(--color-pill-border);
+  border-radius: 62.4375rem;
+  font: var(--font-chip);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.format-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  margin: 0;
+  padding-block: 0.25rem;
+  padding-inline: 0.25rem;
+  background: var(--color-page);
+  border: 0.0625rem solid var(--color-header-border);
+  border-radius: 0.375rem;
+}
+
+.format-toggle legend {
+  position: absolute;
+  inline-size: 0.0625rem;
+  block-size: 0.0625rem;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+
+.format-toggle label {
+  display: block;
+  cursor: pointer;
+}
+
+.format-toggle input {
+  position: absolute;
+  opacity: 0;
+}
+
+.format-toggle span {
+  display: block;
+  border-radius: 0.25rem;
+  padding-block: 0.35rem;
+  padding-inline: 0.65rem;
+  color: var(--color-toggle-text);
+  cursor: pointer;
+  font: var(--font-control);
+  letter-spacing: 0.01em;
+}
+
+.format-toggle input:checked + span {
+  color: var(--color-panel);
+  background: var(--color-heading);
+}
+
+.editor {
+  display: block;
+  min-inline-size: 0;
+  min-block-size: 0;
+}
+
+.code-editor-host,
+.cm-editor {
+  block-size: 100%;
+}
+
+.cm-editor {
+  color: var(--color-editor-text);
+  background: var(--color-editor);
+  font: var(--font-editor);
+}
+
+.cm-editor.cm-focused {
+  outline: 0.1875rem solid var(--color-focus);
+  outline-offset: -0.1875rem;
+}
+
+.cm-scroller {
+  line-height: var(--line-height-editor);
+}
+
+.cm-content,
+.cm-gutters {
+  min-block-size: 100%;
+}
+
+.cm-gutters {
+  color: var(--color-ui-subtle);
+  background: var(--color-editor-gutter);
+  border-inline-end: 0.0625rem solid var(--color-panel-rule);
+}
+
+.output-editor .cm-editor {
+  background: var(--color-editor-output);
+}
+
+.success-message {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  margin: 0;
+  padding-block: 0.85rem;
+  padding-inline: 1rem;
+  color: var(--color-success-ink);
+  background: var(--color-success);
+  border-block-end: 0.0625rem solid var(--color-success-border);
+}
+
+.success-message strong {
+  font: var(--font-success);
+}
+
+.success-message span {
+  color: var(--color-success-muted);
+  font: var(--font-success-detail);
+}
+
+.result-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  margin: 0;
+  border-block-start: 0.0625rem solid var(--color-panel-divider);
+}
+
+.result-stats div {
+  min-inline-size: 0;
+  padding-block: 0.7rem 0.75rem;
+  padding-inline: 1rem;
+  border-inline-end: 0.0625rem solid var(--color-panel-rule);
+}
+
+.result-stats div:last-child {
+  border-inline-end: 0;
+}
+
+.result-stats dt {
+  color: var(--color-ui-muted);
+  font: var(--font-caption-strong);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.result-stats dd {
+  margin-block: 0.1rem 0;
+  margin-inline: 0;
+  color: var(--color-heading);
+  font: var(--font-stat);
+}
+
+@media (width <= 56.25rem) {
+  .app-shell {
+    min-block-size: auto;
+  }
+
+  .app-header,
+  .workspace {
+    grid-template-columns: 1fr;
+  }
+
+  .header-actions {
+    justify-content: flex-start;
+  }
+
+  .panel {
+    min-block-size: 32rem;
+  }
+}
+
+@media (width <= 38.75rem) {
+  .app-shell {
+    padding-block: 0.7rem;
+    padding-inline: 0.7rem;
+  }
+
+  .app-header,
+  .panel-header {
+    padding-block: 0.85rem;
+    padding-inline: 0.85rem;
+  }
+
+  .output-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .format-toggle {
+    inline-size: 100%;
+  }
+
+  .format-toggle label {
+    flex: 1;
+  }
+
+  .format-toggle span {
+    text-align: center;
+  }
+
+  .result-stats {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .success-message {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+}

--- a/web/tests/e2e/validator.e2e.ts
+++ b/web/tests/e2e/validator.e2e.ts
@@ -1,0 +1,120 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const INVALID_CSS = `@property --brand-color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: transparent;
+}
+
+.card {
+  inline-size: var(--brand-color);
+}`;
+
+const VALID_CSS = `@property --space {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+
+.card {
+  inline-size: var(--space);
+}`;
+
+async function replaceEditorContents(page: Page, css: string) {
+  const editor = page.getByRole("textbox", { name: "CSS input" });
+
+  await editor.click();
+  await page.keyboard.press(process.platform === "darwin" ? "Meta+A" : "Control+A");
+  await page.keyboard.type(css);
+}
+
+test("renders the validator workspace", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.locator("body")).toMatchAriaSnapshot(`
+    - banner:
+      - paragraph: Browser validator
+      - heading "CSS Property Type Validator" [level=1]
+      - paragraph:
+        - text: Paste or open a CSS file, then validate typed custom properties and var() usage locally in your browser.
+        - link "View repo":
+          - /url: https://github.com/schalkneethling/css-property-type-validator
+      - region "Validation actions":
+        - heading "Validation actions" [level=2]
+        - text: Open CSS
+        - button "Open CSS"
+        - button "Validate"
+    - main:
+      - article "Validator workspace":
+        - heading "Validator workspace" [level=2]
+        - region "CSS source":
+          - paragraph: Input
+          - heading "CSS source" [level=2]
+          - text: pasted.css
+          - textbox "CSS input"
+        - region "Validation result":
+          - paragraph: Output
+          - heading "Validation result" [level=2]
+          - group "Output format":
+            - text: Output format
+            - radio "Human" [checked]
+            - text: Human
+            - radio "JSON"
+            - text: JSON
+          - textbox "Validation output"
+          - region "Validation summary":
+            - heading "Validation summary" [level=3]
+            - term: Diagnostics
+            - definition: —
+            - term: Registered
+            - definition: —
+            - term: Validated
+            - definition: —
+            - term: Skipped
+            - definition: —
+  `);
+  await expect(page.getByLabel("Open CSS")).toBeAttached();
+});
+
+test("shows a human diagnostic for pasted invalid CSS", async ({ page }) => {
+  await page.goto("/");
+  await replaceEditorContents(page, INVALID_CSS);
+  await page.getByRole("button", { name: "Validate" }).click();
+  const outputPanel = page.getByRole("region", { name: "Validation result" });
+
+  await expect(outputPanel.getByText("incompatible-var-usage")).toBeVisible();
+  await expect(outputPanel.getByText("Registered property --brand-color")).toContainText(
+    "inline-size",
+  );
+});
+
+test("switches diagnostics to pretty JSON", async ({ page }) => {
+  await page.goto("/");
+  await replaceEditorContents(page, INVALID_CSS);
+  await page.getByRole("button", { name: "Validate" }).click();
+  await page.getByLabel("JSON").check();
+
+  await expect(page.getByText('"diagnostics": [')).toBeVisible();
+  await expect(page.getByText('"code": "incompatible-var-usage"')).toBeVisible();
+});
+
+test("shows the success state for valid CSS", async ({ page }) => {
+  await page.goto("/");
+  await replaceEditorContents(page, VALID_CSS);
+  await page.getByRole("button", { name: "Validate" }).click();
+
+  await expect(page.getByRole("status")).toContainText("No validation issues found.");
+  await expect(page.getByLabel("Validation summary")).toContainText("Diagnostics");
+  await expect(page.getByLabel("Validation summary")).toContainText("0");
+});
+
+test("opens a CSS fixture and validates it", async ({ page }) => {
+  await page.goto("/");
+  await page.getByLabel("Open CSS").setInputFiles("tests/fixtures/valid.css");
+
+  await expect(page.getByText("valid.css")).toBeVisible();
+  await expect(page.getByRole("textbox", { name: "CSS input" })).toContainText("--brand-color");
+
+  await page.getByRole("button", { name: "Validate" }).click();
+  await expect(page.getByRole("status")).toContainText("No validation issues found.");
+});

--- a/web/tests/fixtures/valid.css
+++ b/web/tests/fixtures/valid.css
@@ -1,0 +1,9 @@
+@property --brand-color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: transparent;
+}
+
+.card {
+  color: var(--brand-color);
+}

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "extends": "../tsconfig.base.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "noEmit": true,
+    "paths": {
+      "@schalkneethling/css-property-type-validator-core": ["../packages/core/src/index.ts"]
+    },
+    "types": ["vite/client"]
+  },
+  "references": [
+    {
+      "path": "../packages/core"
+    }
+  ],
+  "include": ["src", "vite.config.ts", "playwright.config.ts", "tests"]
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,0 +1,17 @@
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  build: {
+    target: "es2022",
+  },
+  preview: {
+    host: "127.0.0.1",
+    port: 4177,
+    strictPort: true,
+  },
+  server: {
+    host: "127.0.0.1",
+    port: 4177,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
Adds the browser validator app under web, shares formatter behavior from core, and includes Playwright coverage. Validated with typecheck, unit tests, build, e2e tests, and the CLI against web/src/styles.css.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a web-based CSS validator UI with file upload capability and integrated code editor
  * Added output format toggle between human-readable and JSON diagnostic formats
  * Integrated real-time validation diagnostics display with status feedback

* **Tests**
  * Added end-to-end test suite with Playwright configuration for the validator interface

* **Chores**
  * Updated workspace configuration for monorepo structure
  * Added test artifact patterns to ignore file

<!-- end of auto-generated comment: release notes by coderabbit.ai -->