### PR TITLE
feat: add fail-fast validation mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 css-property-type-validator "src/tokens/**/*.css" --registry-only
+css-property-type-validator "src/**/*.css" --failfast
 ```
 
 Use `--registry` for shared `@property` definitions that should contribute registrations without validating ordinary declarations from those files:
@@ -61,6 +62,11 @@ css-property-type-validator "src/tokens/**/*.css" --registry-only
 ```
 
 Registry-only files still report parse errors and invalid `@property` registrations.
+
+By default, the CLI collects every validation failure it can find and reports the full result set.
+Use `--failfast` when you want it to stop after the first validation failure, including
+registration/import failures and declaration usage failures. Human and JSON output keep the same
+format; the diagnostics array simply contains the first issue found.
 
 ## Library Usage
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -23,6 +23,7 @@ css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 css-property-type-validator "src/tokens/**/*.css" --registry-only
+css-property-type-validator "src/**/*.css" --failfast
 ```
 
 Use `--registry` multiple times to include shared registration sources:
@@ -34,6 +35,8 @@ css-property-type-validator "src/**/*.css" \
 ```
 
 The CLI follows local unconditioned `@import` rules while assembling the registry, including relative and root-relative imports. Remote and conditioned imports are skipped.
+
+By default, the CLI collects and reports all validation failures. Use `--failfast` to stop after the first validation failure, whether it comes from registry assembly, `@property` validation, or declaration usage validation. Exit codes and human/JSON output formats are unchanged.
 
 ## Exit Codes
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -83,6 +83,7 @@ async function main(): Promise<void> {
     .description("Validate @property registrations and var() usages across CSS files.")
     .argument("[patterns...]", "CSS files or glob patterns to validate")
     .option("-f, --format <format>", "output format: human or json", "human")
+    .option("--failfast", "stop after the first validation failure", false)
     .option(
       "-r, --registry <pattern>",
       "CSS file or glob pattern to use for shared @property registrations",
@@ -97,7 +98,12 @@ async function main(): Promise<void> {
     .action(
       async (
         patterns: string[],
-        options: { format: OutputFormat; registry: string[]; registryOnly: boolean },
+        options: {
+          failfast: boolean;
+          format: OutputFormat;
+          registry: string[];
+          registryOnly: boolean;
+        },
       ) => {
         const format = resolveOutputFormat(options.format);
 
@@ -125,6 +131,7 @@ async function main(): Promise<void> {
             registryInputs,
           );
           const result = validateFiles([], {
+            failFast: options.failfast,
             registryInputs: [...registryInputs, ...additionalRegistryInputs],
             resolveImport: createImportResolver(process.cwd()),
           });
@@ -147,6 +154,7 @@ async function main(): Promise<void> {
 
         const registryInputs = await loadRegistryInputs(options.registry, inputs);
         const result = validateFiles(inputs, {
+          failFast: options.failfast,
           registryInputs,
           resolveImport: createImportResolver(process.cwd()),
         });

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -426,7 +426,7 @@ function processPropertyRule(
 
 export function collectRegistry(
   inputs: ValidationInput[],
-  options: { resolveImport?: ResolveImport } = {},
+  options: { failFast?: boolean; resolveImport?: ResolveImport } = {},
 ): {
   diagnostics: ValidationDiagnostic[];
   registry: RegisteredProperty[];
@@ -487,15 +487,24 @@ export function collectRegistry(
             message: `Could not resolve imported stylesheet "${importSpecifier}" from ${input.path}.`,
             snippet: cssTree.generate(node),
           });
+          if (options.failFast) {
+            break;
+          }
           continue;
         }
 
         processInput(resolvedImport);
+        if (options.failFast && diagnostics.length > 0) {
+          break;
+        }
         continue;
       }
 
       if (node.name === "property") {
         processPropertyRule(input, node, diagnostics, registry);
+        if (options.failFast && diagnostics.length > 0) {
+          break;
+        }
       }
     }
 
@@ -505,6 +514,9 @@ export function collectRegistry(
 
   for (const input of inputs) {
     processInput(input);
+    if (options.failFast && diagnostics.length > 0) {
+      break;
+    }
   }
 
   return {

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -27,6 +27,7 @@ import type {
 } from "./var-substitution.js";
 
 export interface ValidateFilesOptions {
+  failFast?: boolean;
   registryInputs?: ValidationInput[];
   resolveImport?: ResolveImport;
 }
@@ -545,12 +546,22 @@ export function validateFiles(
   }
 
   const registryResult = collectRegistry(registrySources, {
+    failFast: options.failFast,
     resolveImport: options.resolveImport,
   });
   const diagnostics = [...registryResult.diagnostics];
   const registry = registryMap(registryResult.registry);
   let skippedDeclarations = 0;
   let validatedDeclarations = 0;
+
+  if (options.failFast && diagnostics.length > 0) {
+    return {
+      diagnostics,
+      registry: registryResult.registry,
+      skippedDeclarations,
+      validatedDeclarations,
+    };
+  }
 
   for (const input of inputs) {
     let ast: CssValueAst;
@@ -560,19 +571,36 @@ export function validateFiles(
         filename: input.path,
         positions: true,
       });
-    } catch {
+    } catch (error) {
+      if (options.failFast) {
+        diagnostics.push({
+          code: "unparseable-stylesheet",
+          filePath: input.path,
+          loc: null,
+          message: `Could not parse stylesheet: ${(error as Error).message}`,
+        });
+        break;
+      }
       continue;
     }
 
     cssTree.walk(ast, {
       visit: "Declaration",
       enter(node: CssWalkNode) {
+        if (options.failFast && diagnostics.length > 0) {
+          return;
+        }
+
         const result = validateDeclaration(input.path, node as CssDeclarationNode, registry);
         diagnostics.push(...result.diagnostics);
         skippedDeclarations += result.skipped;
         validatedDeclarations += result.validated;
       },
     });
+
+    if (options.failFast && diagnostics.length > 0) {
+      break;
+    }
   }
 
   return {

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -58,6 +58,53 @@ describe("validateFiles", () => {
     expect(result.diagnostics[0]?.expectedProperty).toBe("inline-size");
   });
 
+  it("stops on the first registration validation failure when fail-fast is enabled", () => {
+    const result = validateFiles(
+      [
+        {
+          path: "/tmp/registry.css",
+          css: [
+            '@property --bad-color { syntax: "<color"; inherits: true; initial-value: transparent; }',
+            '@property --bad-space { syntax: "<length>"; inherits: maybe; initial-value: 0px; }',
+          ].join("\n"),
+        },
+      ],
+      { failFast: true },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.propertyName).toBe("--bad-color");
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it("stops on the first usage validation failure when fail-fast is enabled", () => {
+    const result = validateFiles(
+      [
+        {
+          path: "/tmp/registry.css",
+          css: [
+            '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+            '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+          ].join("\n"),
+        },
+        {
+          path: "/tmp/usage.css",
+          css: [
+            ".card { inline-size: var(--brand-color); }",
+            ".stack { color: var(--space); }",
+          ].join("\n"),
+        },
+      ],
+      { failFast: true },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.diagnostics[0]?.expectedProperty).toBe("inline-size");
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
   it("ignores unregistered custom properties", () => {
     const result = runValidation({
       "/tmp/usage.css": ".card { inline-size: var(--space); }",
@@ -894,6 +941,7 @@ describe("validateFiles", () => {
     expect(cliResult.stdout).toContain("--format");
     expect(cliResult.stdout).toContain("--registry");
     expect(cliResult.stdout).toContain("--registry-only");
+    expect(cliResult.stdout).toContain("--failfast");
   });
 
   it("keeps human CLI output stable for a clean validation run", { timeout: 120000 }, () => {
@@ -949,6 +997,60 @@ describe("validateFiles", () => {
     );
     expect(cliResult.stdout).toContain("inline-size:var(--brand-color)");
   });
+
+  it(
+    "limits CLI json output to the first validation failure with --failfast",
+    { timeout: 120000 },
+    () => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+      const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+      const validationPath = path.join(fixtureDir, "component.css");
+      const registryPath = path.join(fixtureDir, "tokens.css");
+
+      writeFileSync(
+        validationPath,
+        [".card { inline-size: var(--brand-color); }", ".stack { color: var(--space); }"].join(
+          "\n",
+        ),
+      );
+      writeFileSync(
+        registryPath,
+        [
+          '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+          '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+        ].join("\n"),
+      );
+
+      const cliResult = spawnSync(
+        "node",
+        [
+          "packages/cli/dist/cli.js",
+          validationPath,
+          "--registry",
+          registryPath,
+          "--format",
+          "json",
+          "--failfast",
+        ],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+        },
+      );
+
+      expect(cliResult.status).toBe(1);
+
+      const report = JSON.parse(cliResult.stdout) as {
+        diagnostics: Array<{ code: string; expectedProperty?: string }>;
+        validatedDeclarations: number;
+      };
+
+      expect(report.diagnostics).toHaveLength(1);
+      expect(report.diagnostics[0]?.code).toBe("incompatible-var-usage");
+      expect(report.diagnostics[0]?.expectedProperty).toBe("inline-size");
+      expect(report.validatedDeclarations).toBe(1);
+    },
+  );
 
   it("builds the public runtime and type exports", { timeout: 120000 }, async () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../..");


### PR DESCRIPTION
## Summary

Adds an explicit `--failfast` CLI option and core `failFast` validation option so validation can stop after the first validation failure while keeping the default collect-all behavior unchanged.

## What Changed

- Threaded `failFast` through CLI and core validation.
- Stops during registry assembly, import diagnostics, parse failures in fail-fast mode, and declaration usage validation once the first validation failure is found.
- Documented the new CLI flag in the root and CLI READMEs.
- Added coverage for registration failures, usage failures, help output, and JSON output.

## Validation

- `pnpm run check`

Closes #26.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--failfast` CLI flag that stops validation after the first encountered failure, whether during registry assembly, property validation, or declaration usage validation.

* **Documentation**
  * Updated documentation with `--failfast` option details, usage examples, and clarification that output formats remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->