### PR TITLE
Add structured metadata to validation diagnostics

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -41,6 +41,47 @@ const result = validateFiles(
 console.log(result.diagnostics);
 ```
 
+Diagnostics include stable machine-readable fields for tooling integrations:
+
+```ts
+type ValidationDiagnostic = {
+  code:
+    | "invalid-property-registration"
+    | "incompatible-custom-property-assignment"
+    | "incompatible-var-usage"
+    | "unresolved-import"
+    | "unparseable-stylesheet";
+  phase: "parse" | "registry" | "assignment" | "usage" | "import";
+  reason:
+    | "missing-property-name"
+    | "missing-syntax-descriptor"
+    | "invalid-syntax-descriptor"
+    | "unsupported-syntax-component"
+    | "missing-inherits-descriptor"
+    | "invalid-inherits-descriptor"
+    | "missing-initial-value-descriptor"
+    | "invalid-initial-value"
+    | "incompatible-assignment-value"
+    | "incompatible-var-substitution"
+    | "incompatible-var-fallback"
+    | "unresolved-import"
+    | "unparseable-css";
+  severity: "error";
+  filePath: string;
+  loc: SourceLocation | null;
+  message: string;
+  descriptorName?: "syntax" | "inherits" | "initial-value";
+  propertyName?: string;
+  registeredSyntax?: string;
+  expectedProperty?: string;
+  actualValue?: string;
+  importSpecifier?: string;
+  snippet?: string;
+};
+```
+
+`code` is the broad diagnostic category, while `phase` and `reason` are intended for rule mapping, editor diagnostics, filtering, and stable automation. Existing fields such as `propertyName`, `registeredSyntax`, and `expectedProperty` remain available for integrations that already consume them.
+
 Provide `resolveImport` when registry assembly should follow local unconditioned imports:
 
 ```ts

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -282,6 +282,9 @@ function processPropertyRule(
   if (!propertyName) {
     diagnostics.push({
       code: "invalid-property-registration",
+      phase: "registry",
+      reason: "missing-property-name",
+      severity: "error",
       filePath: input.path,
       loc: toLocation(node.loc),
       message: "Found an @property rule without a custom property name.",
@@ -300,9 +303,13 @@ function processPropertyRule(
   if (!syntax) {
     diagnostics.push({
       code: "invalid-property-registration",
+      phase: "registry",
+      reason: "missing-syntax-descriptor",
+      severity: "error",
       filePath: input.path,
       loc: toLocation(node.loc),
       message: `@property ${propertyName} is missing a valid string-valued syntax descriptor.`,
+      descriptorName: "syntax",
       propertyName,
     });
     return;
@@ -317,9 +324,13 @@ function processPropertyRule(
   } catch (error) {
     diagnostics.push({
       code: "invalid-property-registration",
+      phase: "registry",
+      reason: "invalid-syntax-descriptor",
+      severity: "error",
       filePath: input.path,
       loc: toLocation(node.loc),
       message: `@property ${propertyName} has an invalid syntax descriptor "${syntax}": ${(error as Error).message}`,
+      descriptorName: "syntax",
       propertyName,
       registeredSyntax: syntax,
     });
@@ -335,9 +346,13 @@ function processPropertyRule(
     if (unsupportedName) {
       diagnostics.push({
         code: "invalid-property-registration",
+        phase: "registry",
+        reason: "unsupported-syntax-component",
+        severity: "error",
         filePath: input.path,
         loc: toLocation(node.loc),
         message: `@property ${propertyName} uses the unsupported syntax component name "${unsupportedName}".`,
+        descriptorName: "syntax",
         propertyName,
         registeredSyntax: syntax,
       });
@@ -352,9 +367,13 @@ function processPropertyRule(
   if (!inheritsDescriptor) {
     diagnostics.push({
       code: "invalid-property-registration",
+      phase: "registry",
+      reason: "missing-inherits-descriptor",
+      severity: "error",
       filePath: input.path,
       loc: toLocation(node.loc),
       message: `@property ${propertyName} is missing the required inherits descriptor.`,
+      descriptorName: "inherits",
       propertyName,
       registeredSyntax: syntax,
     });
@@ -364,9 +383,14 @@ function processPropertyRule(
   if (inherits === undefined) {
     diagnostics.push({
       code: "invalid-property-registration",
+      phase: "registry",
+      reason: "invalid-inherits-descriptor",
+      severity: "error",
       filePath: input.path,
       loc: toLocation(node.loc),
       message: `@property ${propertyName} must set inherits to true or false.`,
+      actualValue: inheritsRaw,
+      descriptorName: "inherits",
       propertyName,
       registeredSyntax: syntax,
     });
@@ -379,9 +403,13 @@ function processPropertyRule(
   if (syntax !== "*" && !initialValue) {
     diagnostics.push({
       code: "invalid-property-registration",
+      phase: "registry",
+      reason: "missing-initial-value-descriptor",
+      severity: "error",
       filePath: input.path,
       loc: toLocation(node.loc),
       message: `@property ${propertyName} is missing the required initial-value descriptor for non-universal syntax "${syntax}".`,
+      descriptorName: "initial-value",
       propertyName,
       registeredSyntax: syntax,
     });
@@ -398,9 +426,14 @@ function processPropertyRule(
     if (initialValueFailure) {
       diagnostics.push({
         code: "invalid-property-registration",
+        phase: "registry",
+        reason: "invalid-initial-value",
+        severity: "error",
         filePath: input.path,
         loc: toLocation(node.loc),
         message: initialValueFailure,
+        actualValue: initialValue,
+        descriptorName: "initial-value",
         propertyName,
         registeredSyntax: syntax,
       });
@@ -456,6 +489,9 @@ export function collectRegistry(
     } catch (error) {
       diagnostics.push({
         code: "unparseable-stylesheet",
+        phase: "parse",
+        reason: "unparseable-css",
+        severity: "error",
         filePath: input.path,
         loc: null,
         message: `Could not parse stylesheet: ${(error as Error).message}`,
@@ -482,9 +518,13 @@ export function collectRegistry(
         if (!resolvedImport) {
           diagnostics.push({
             code: "unresolved-import",
+            phase: "import",
+            reason: "unresolved-import",
+            severity: "error",
             filePath: input.path,
             loc: toLocation(node.loc),
             message: `Could not resolve imported stylesheet "${importSpecifier}" from ${input.path}.`,
+            importSpecifier,
             snippet: cssTree.generate(node),
           });
           if (options.failFast) {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -33,14 +33,39 @@ export type DiagnosticCode =
   | "unresolved-import"
   | "unparseable-stylesheet";
 
+export type DiagnosticSeverity = "error";
+
+export type DiagnosticPhase = "parse" | "registry" | "assignment" | "usage" | "import";
+
+export type DiagnosticReason =
+  | "missing-property-name"
+  | "missing-syntax-descriptor"
+  | "invalid-syntax-descriptor"
+  | "unsupported-syntax-component"
+  | "missing-inherits-descriptor"
+  | "invalid-inherits-descriptor"
+  | "missing-initial-value-descriptor"
+  | "invalid-initial-value"
+  | "incompatible-assignment-value"
+  | "incompatible-var-substitution"
+  | "incompatible-var-fallback"
+  | "unresolved-import"
+  | "unparseable-css";
+
 export interface ValidationDiagnostic {
   code: DiagnosticCode;
+  phase: DiagnosticPhase;
+  reason: DiagnosticReason;
+  severity: DiagnosticSeverity;
   filePath: string;
   loc: SourceLocation | null;
   message: string;
+  descriptorName?: "syntax" | "inherits" | "initial-value";
   propertyName?: string;
   registeredSyntax?: string;
   expectedProperty?: string;
+  actualValue?: string;
+  importSpecifier?: string;
   snippet?: string;
 }
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -157,6 +157,9 @@ function toVarDiagnostic(
 
     return {
       code: "incompatible-var-usage",
+      phase: "usage",
+      reason: "incompatible-var-substitution",
+      severity: "error",
       filePath,
       loc: toLocation(varNode.loc),
       message: `Registered property ${registration.name} uses syntax "${registration.syntax}" which is incompatible with ${declaration.property} at this var() usage.`,
@@ -173,6 +176,9 @@ function toVarDiagnostic(
 
   return {
     code: "incompatible-var-usage",
+    phase: "usage",
+    reason: "incompatible-var-substitution",
+    severity: "error",
     filePath,
     loc: toLocation(declaration.value.loc),
     message: `Registered properties ${registeredNames} are jointly incompatible with ${declaration.property} at this declaration value.`,
@@ -194,6 +200,9 @@ function toPossibleVarDiagnostic(
 
   return {
     code: "incompatible-var-usage",
+    phase: "usage",
+    reason: "incompatible-var-substitution",
+    severity: "error",
     filePath,
     loc: toLocation(declaration.value.loc),
     message,
@@ -209,9 +218,13 @@ function toAssignmentDiagnostic(
 ): ValidationDiagnostic {
   return {
     code: "incompatible-custom-property-assignment",
+    phase: "assignment",
+    reason: "incompatible-assignment-value",
+    severity: "error",
     filePath,
     loc: toLocation(declaration.value.loc ?? declaration.loc),
     message: `Assigned value for registered property ${registration.name} does not match its syntax "${registration.syntax}".`,
+    actualValue: cssTree.generate(declaration.value).trim(),
     propertyName: registration.name,
     registeredSyntax: registration.syntax,
     snippet: cssTree.generate(declaration),
@@ -226,6 +239,9 @@ function toFallbackDiagnostic(
 ): ValidationDiagnostic {
   return {
     code: "incompatible-var-usage",
+    phase: "usage",
+    reason: "incompatible-var-fallback",
+    severity: "error",
     filePath,
     loc: toLocation(varNode.loc),
     message: `Fallback value in var() for registered property ${registration.name} is incompatible with ${declaration.property} at this var() usage.`,
@@ -572,13 +588,17 @@ export function validateFiles(
         positions: true,
       });
     } catch (error) {
+      diagnostics.push({
+        code: "unparseable-stylesheet",
+        phase: "parse",
+        reason: "unparseable-css",
+        severity: "error",
+        filePath: input.path,
+        loc: null,
+        message: `Could not parse stylesheet: ${(error as Error).message}`,
+      });
+
       if (options.failFast) {
-        diagnostics.push({
-          code: "unparseable-stylesheet",
-          filePath: input.path,
-          loc: null,
-          message: `Could not parse stylesheet: ${(error as Error).message}`,
-        });
         break;
       }
       continue;

--- a/packages/core/test/formatter.test.ts
+++ b/packages/core/test/formatter.test.ts
@@ -21,6 +21,9 @@ describe("formatValidationResult", () => {
       diagnostics: [
         {
           code: "incompatible-var-usage",
+          phase: "usage",
+          reason: "incompatible-var-substitution",
+          severity: "error",
           expectedProperty: "inline-size",
           filePath: "component.css",
           loc: {
@@ -52,8 +55,12 @@ describe("formatValidationResult", () => {
       diagnostics: [
         {
           code: "incompatible-var-usage",
+          phase: "usage",
+          reason: "incompatible-var-substitution",
+          severity: "error",
           expectedProperty: "inline-size",
           filePath: "component.css",
+          loc: null,
           message: "Registered property --brand-color is incompatible.",
           propertyName: "--brand-color",
           registeredSyntax: "<color>",
@@ -77,16 +84,24 @@ describe("formatValidationResult", () => {
       diagnostics: [
         {
           code: "incompatible-var-usage",
+          phase: "usage",
+          reason: "incompatible-var-substitution",
+          severity: "error",
           expectedProperty: "inline-size",
           filePath: "component.css",
+          loc: null,
           message: "Registered property --brand-color is incompatible.",
           propertyName: "--brand-color",
           registeredSyntax: "<color>",
         },
         {
           code: "incompatible-var-usage",
+          phase: "usage",
+          reason: "incompatible-var-substitution",
+          severity: "error",
           expectedProperty: "block-size",
           filePath: "card.css",
+          loc: null,
           message: "Registered property --space is incompatible.",
           propertyName: "--space",
           registeredSyntax: "<color>",

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -55,7 +55,24 @@ describe("validateFiles", () => {
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.diagnostics[0]?.phase).toBe("usage");
+    expect(result.diagnostics[0]?.reason).toBe("incompatible-var-substitution");
+    expect(result.diagnostics[0]?.severity).toBe("error");
     expect(result.diagnostics[0]?.expectedProperty).toBe("inline-size");
+  });
+
+  it("reports unparseable validation inputs without fail-fast", () => {
+    const result = validateFiles([
+      { path: "/tmp/broken.css", css: null as unknown as string },
+      { path: "/tmp/valid.css", css: ".card { color: red; }" },
+    ]);
+
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics[1]?.code).toBe("unparseable-stylesheet");
+    expect(result.diagnostics[1]?.phase).toBe("parse");
+    expect(result.diagnostics[1]?.reason).toBe("unparseable-css");
+    expect(result.diagnostics[1]?.severity).toBe("error");
+    expect(result.diagnostics[1]?.filePath).toBe("/tmp/broken.css");
   });
 
   it("stops on the first registration validation failure when fail-fast is enabled", () => {
@@ -124,6 +141,9 @@ describe("validateFiles", () => {
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("invalid-property-registration");
+    expect(result.diagnostics[0]?.phase).toBe("registry");
+    expect(result.diagnostics[0]?.reason).toBe("invalid-syntax-descriptor");
+    expect(result.diagnostics[0]?.descriptorName).toBe("syntax");
   });
 
   it("reports missing string-valued syntax descriptors in @property rules", () => {
@@ -319,6 +339,9 @@ describe("validateFiles", () => {
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("incompatible-custom-property-assignment");
+    expect(result.diagnostics[0]?.phase).toBe("assignment");
+    expect(result.diagnostics[0]?.reason).toBe("incompatible-assignment-value");
+    expect(result.diagnostics[0]?.actualValue).toBe("10px");
     expect(result.diagnostics[0]?.propertyName).toBe("--brand-color");
     expect(result.diagnostics[0]?.expectedProperty).toBeUndefined();
     expect(result.validatedDeclarations).toBe(1);
@@ -409,6 +432,8 @@ describe("validateFiles", () => {
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.diagnostics[0]?.phase).toBe("usage");
+    expect(result.diagnostics[0]?.reason).toBe("incompatible-var-fallback");
     expect(result.diagnostics[0]?.message).toContain("Fallback value in var()");
     expect(result.diagnostics[0]?.message).toContain("--brand-color");
     expect(result.diagnostics[0]?.expectedProperty).toBe("color");
@@ -797,6 +822,9 @@ describe("validateFiles", () => {
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("unresolved-import");
+    expect(result.diagnostics[0]?.phase).toBe("import");
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-import");
+    expect(result.diagnostics[0]?.importSpecifier).toBe("./missing.css");
     expect(result.diagnostics[0]?.message).toContain("./missing.css");
   });
 


### PR DESCRIPTION
## Summary
- Add stable machine-readable fields to `ValidationDiagnostic` for tooling integrations
- Include `phase`, `reason`, and `severity` on all diagnostics
- Add structured context for descriptor errors, assignment values, and unresolved imports
- Document the diagnostic contract in the core README
- Update tests to cover the richer JSON shape and preserve existing fields

## Testing
- Core unit tests updated for formatter and validation diagnostics
- Typecheck and workspace build passed
- Local validation covered registry, assignment, usage, fallback, and import diagnostics

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostics now include structured metadata—severity levels, processing phases, and reason codes—enabling better tooling integrations and clearer error reporting.

* **Documentation**
  * Updated diagnostics documentation to describe stable, machine-readable diagnostic fields designed for integration with development tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->