### PR TITLE
feat(core): report unresolved var references

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSS Property Type Validator
 
-Validate CSS custom property registrations declared with `@property`, then check whether registered custom properties are used compatibly through `var()`.
+Validate CSS custom property registrations declared with `@property`, then check whether registered custom properties are used compatibly through `var()` and whether referenced custom properties are known to the validator.
 
 Use it when your design tokens or component styles rely on typed custom properties and you want CI to catch mistakes such as a color token being used for `inline-size`, or a length token being assigned an invalid value.
 
@@ -12,7 +12,8 @@ Use it when your design tokens or component styles rely on typed custom properti
 - Checks registered `var()` usages against the consuming CSS property
 - Checks simple `var()` fallback branches against the consuming CSS property
 - Validates authored values assigned directly to registered custom properties
-- Ignores unregistered custom properties
+- Reports unknown no-fallback `var()` references from known CSS inputs
+- Ignores unknown custom properties when that `var()` call provides a fallback
 - Skips ambiguous cases conservatively to avoid false positives
 
 ## Packages
@@ -130,7 +131,9 @@ Locations are included when available.
 
 The validator assembles one registry from the full set of validation inputs, registry-only inputs, and resolved local imports. It then checks each validation input against that combined registry.
 
-When a resolver is available, the core follows local unconditioned `@import` rules while assembling the registry. The CLI provides a resolver for relative and root-relative local CSS imports. Remote imports and conditioned imports are intentionally out of scope for now.
+When a resolver is available, the core follows local unconditioned `@import` rules while assembling the registry and known custom property inputs. The CLI provides a resolver for relative and root-relative local CSS imports. Remote imports and conditioned imports are intentionally out of scope for now.
+
+Unresolved `var()` diagnostics are static known-inputs checks. They report `var(--token)` when `--token` is absent from known files/imports/registry inputs and no fallback is provided, but they do not attempt a full browser cascade evaluation for a specific DOM element.
 
 Compatibility checks are conservative:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 Command-line interface for CSS Property Type Validator.
 
-Use it locally or in CI to validate CSS `@property` registrations, registered `var()` usage, simple fallback branches, and authored assignments to registered custom properties.
+Use it locally or in CI to validate CSS `@property` registrations, registered `var()` usage, unresolved no-fallback `var()` references from known CSS inputs, simple fallback branches, and authored assignments to registered custom properties.
 
 ## Install
 
@@ -34,7 +34,9 @@ css-property-type-validator "src/**/*.css" \
   --registry "src/brand/**/*.css"
 ```
 
-The CLI follows local unconditioned `@import` rules while assembling the registry, including relative and root-relative imports. Remote and conditioned imports are skipped.
+The CLI follows local unconditioned `@import` rules while assembling the registry and known custom property inputs, including relative and root-relative imports. Remote and conditioned imports are skipped.
+
+Unresolved `var()` diagnostics are static known-inputs checks. They report `var(--token)` when `--token` is absent from known files/imports/registry inputs and no fallback is provided, but they do not attempt a full browser cascade evaluation for a specific DOM element.
 
 By default, the CLI collects and reports all validation failures. Use `--failfast` to stop after the first validation failure, whether it comes from registry assembly, `@property` validation, or declaration usage validation. Exit codes and human/JSON output formats are unchanged.
 

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schalkneethling/css-property-type-validator-cli",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "CLI for CSS custom property type validator.",
   "keywords": [
     "cli",

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Core validation engine for CSS Property Type Validator.
 
-It reads CSS `@property` registrations, builds a registry of typed custom properties, validates registration descriptors, checks compatible `var()` usage against consuming CSS properties, validates simple fallback branches, and checks authored assignments to registered custom properties.
+It reads CSS `@property` registrations, builds a registry of typed custom properties, validates registration descriptors, checks compatible `var()` usage against consuming CSS properties, reports unresolved no-fallback `var()` references from known CSS inputs, validates simple fallback branches, and checks authored assignments to registered custom properties.
 
 ## Install
 
@@ -64,6 +64,7 @@ type ValidationDiagnostic = {
     | "incompatible-assignment-value"
     | "incompatible-var-substitution"
     | "incompatible-var-fallback"
+    | "unresolved-var-reference"
     | "unresolved-import"
     | "unparseable-css";
   severity: "error";
@@ -82,7 +83,7 @@ type ValidationDiagnostic = {
 
 `code` is the broad diagnostic category, while `phase` and `reason` are intended for rule mapping, editor diagnostics, filtering, and stable automation. Existing fields such as `propertyName`, `registeredSyntax`, and `expectedProperty` remain available for integrations that already consume them.
 
-Provide `resolveImport` when registry assembly should follow local unconditioned imports:
+Provide `resolveImport` when registry assembly and known custom property checks should follow local unconditioned imports:
 
 ```ts
 const result = validateFiles(inputs, {
@@ -96,7 +97,8 @@ const result = validateFiles(inputs, {
 ## Notes
 
 - `registryInputs` contribute registrations and registration diagnostics without validating ordinary declarations from those files.
-- Unregistered custom properties are ignored.
+- `unresolved-var-reference` is a static known-inputs diagnostic. It reports `var(--token)` when `--token` is absent from known files/imports/registry inputs and no fallback is provided; it does not attempt a full browser cascade evaluation for a specific DOM element.
+- Unknown custom properties with fallbacks, such as `var(--token, red)`, do not report `unresolved-var-reference`.
 - Ambiguous cases are skipped conservatively to avoid false positives.
 - Remote and conditioned imports are out of scope unless a future validation model can handle them safely.
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schalkneethling/css-property-type-validator-core",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Standalone CSS custom property type validator core.",
   "keywords": [
     "css",

--- a/packages/core/src/imports.ts
+++ b/packages/core/src/imports.ts
@@ -1,0 +1,46 @@
+interface CssPreludeNode {
+  children?: ArrayLike<unknown>;
+}
+
+export interface CssAtruleNode {
+  name?: string;
+  prelude?: CssPreludeNode;
+  type?: string;
+}
+
+interface CssStringNode {
+  type: "String";
+  value?: string;
+}
+
+interface CssUrlNode {
+  type: "Url";
+  value?: string;
+}
+
+export function getImportSpecifier(importRule: CssAtruleNode): string | null {
+  const preludeChildren = Array.from(importRule.prelude?.children ?? []) as Array<
+    CssStringNode | CssUrlNode
+  >;
+
+  if (preludeChildren.length !== 1) {
+    return null;
+  }
+
+  const firstPreludeNode = preludeChildren[0];
+
+  if (firstPreludeNode?.type === "String" || firstPreludeNode?.type === "Url") {
+    return String(firstPreludeNode.value ?? "");
+  }
+
+  return null;
+}
+
+export function isAbsoluteImportUrl(importSpecifier: string): boolean {
+  try {
+    new URL(importSpecifier);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/core/src/imports.ts
+++ b/packages/core/src/imports.ts
@@ -37,6 +37,10 @@ export function getImportSpecifier(importRule: CssAtruleNode): string | null {
 }
 
 export function isAbsoluteImportUrl(importSpecifier: string): boolean {
+  if (importSpecifier.startsWith("//")) {
+    return true;
+  }
+
   try {
     new URL(importSpecifier);
     return true;

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -1,5 +1,6 @@
 import * as cssTree from "css-tree";
 
+import { getImportSpecifier, isAbsoluteImportUrl } from "./imports.js";
 import { getFirstUnsupportedSyntaxComponentName } from "./supported-syntax.js";
 
 import type {
@@ -39,11 +40,6 @@ interface CssAtruleNode extends CssNodeWithLoc {
 
 interface CssStringNode {
   type: "String";
-  value?: string;
-}
-
-interface CssUrlNode {
-  type: "Url";
   value?: string;
 }
 
@@ -242,33 +238,6 @@ function getRawDescriptor(declaration: CssDeclarationNode | undefined): string |
   }
 
   return cssTree.generate(declaration.value).trim();
-}
-
-function getImportSpecifier(importRule: CssAtruleNode): string | null {
-  const preludeChildren = Array.from(importRule.prelude?.children ?? []) as Array<
-    CssStringNode | CssUrlNode
-  >;
-
-  if (preludeChildren.length !== 1) {
-    return null;
-  }
-
-  const firstPreludeNode = preludeChildren[0];
-
-  if (firstPreludeNode?.type === "String" || firstPreludeNode?.type === "Url") {
-    return String(firstPreludeNode.value ?? "");
-  }
-
-  return null;
-}
-
-function isAbsoluteImportUrl(importSpecifier: string): boolean {
-  try {
-    new URL(importSpecifier);
-    return true;
-  } catch {
-    return false;
-  }
 }
 
 function processPropertyRule(

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -49,6 +49,7 @@ export type DiagnosticReason =
   | "incompatible-assignment-value"
   | "incompatible-var-substitution"
   | "incompatible-var-fallback"
+  | "unresolved-var-reference"
   | "unresolved-import"
   | "unparseable-css";
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -718,12 +718,6 @@ export function validateFiles(
   });
   const diagnostics = [...registryResult.diagnostics];
   const registry = registryMap(registryResult.registry);
-  const knownCustomPropertiesByPath = collectKnownCustomProperties(
-    inputs,
-    registryInputs,
-    registry,
-    options.resolveImport,
-  );
   let skippedDeclarations = 0;
   let validatedDeclarations = 0;
 
@@ -735,6 +729,13 @@ export function validateFiles(
       validatedDeclarations,
     };
   }
+
+  const knownCustomPropertiesByPath = collectKnownCustomProperties(
+    inputs,
+    registryInputs,
+    registry,
+    options.resolveImport,
+  );
 
   for (const input of inputs) {
     let ast: CssValueAst;

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -54,6 +54,18 @@ type CssLocation = NonNullable<ValidationDiagnostic["loc"]>;
 
 const PROPERTY_RULE_DESCRIPTOR_NAMES = Object.freeze(["syntax", "inherits", "initial-value"]);
 
+type ParsedStylesheet = CssValueAst & { children?: ArrayLike<unknown> };
+
+type ParsedStylesheetResult =
+  | {
+      ast: ParsedStylesheet;
+      error: null;
+    }
+  | {
+      ast: null;
+      error: Error;
+    };
+
 function toLocation(loc: unknown): ValidationDiagnostic["loc"] {
   if (!loc) {
     return null;
@@ -90,10 +102,42 @@ function mergeInto(target: Set<string>, source: Iterable<string>): void {
   }
 }
 
+function parseStylesheet(
+  input: ValidationInput,
+  parsedAstByPath: Map<string, ParsedStylesheetResult>,
+): ParsedStylesheetResult {
+  const cached = parsedAstByPath.get(input.path);
+
+  if (cached) {
+    return cached;
+  }
+
+  let result: ParsedStylesheetResult;
+
+  try {
+    result = {
+      ast: cssTree.parse(input.css, {
+        filename: input.path,
+        positions: true,
+      }) as ParsedStylesheet,
+      error: null,
+    };
+  } catch (error) {
+    result = {
+      ast: null,
+      error: error as Error,
+    };
+  }
+
+  parsedAstByPath.set(input.path, result);
+  return result;
+}
+
 function collectKnownCustomProperties(
   inputs: ValidationInput[],
   registryInputs: ValidationInput[],
   registry: Map<string, RegisteredProperty>,
+  parsedAstByPath: Map<string, ParsedStylesheetResult>,
   resolveImport?: ResolveImport,
 ): Map<string, Set<string>> {
   const byPath = new Map<string, Set<string>>();
@@ -114,19 +158,14 @@ function collectKnownCustomProperties(
 
     activePaths.add(input.path);
 
-    let ast: CssValueAst;
+    const parsed = parseStylesheet(input, parsedAstByPath);
 
-    try {
-      ast = cssTree.parse(input.css, {
-        filename: input.path,
-        positions: true,
-      });
-    } catch {
+    if (!parsed.ast) {
       activePaths.delete(input.path);
       return known;
     }
 
-    cssTree.walk(ast, {
+    cssTree.walk(parsed.ast, {
       visit: "Declaration",
       enter(node: CssWalkNode) {
         const declaration = node as CssDeclarationNode;
@@ -137,9 +176,7 @@ function collectKnownCustomProperties(
       },
     });
 
-    for (const node of Array.from(
-      (ast as { children?: ArrayLike<unknown> }).children ?? [],
-    ) as CssAtruleNode[]) {
+    for (const node of Array.from(parsed.ast.children ?? []) as CssAtruleNode[]) {
       if (node.type !== "Atrule" || node.name !== "import") {
         continue;
       }
@@ -730,22 +767,19 @@ export function validateFiles(
     };
   }
 
+  const parsedAstByPath = new Map<string, ParsedStylesheetResult>();
   const knownCustomPropertiesByPath = collectKnownCustomProperties(
     inputs,
     registryInputs,
     registry,
+    parsedAstByPath,
     options.resolveImport,
   );
 
   for (const input of inputs) {
-    let ast: CssValueAst;
+    const parsed = parseStylesheet(input, parsedAstByPath);
 
-    try {
-      ast = cssTree.parse(input.css, {
-        filename: input.path,
-        positions: true,
-      });
-    } catch (error) {
+    if (!parsed.ast) {
       diagnostics.push({
         code: "unparseable-stylesheet",
         phase: "parse",
@@ -753,7 +787,7 @@ export function validateFiles(
         severity: "error",
         filePath: input.path,
         loc: null,
-        message: `Could not parse stylesheet: ${(error as Error).message}`,
+        message: `Could not parse stylesheet: ${parsed.error.message}`,
       });
 
       if (options.failFast) {
@@ -762,7 +796,7 @@ export function validateFiles(
       continue;
     }
 
-    cssTree.walk(ast, {
+    cssTree.walk(parsed.ast, {
       visit: "Declaration",
       enter(node: CssWalkNode) {
         if (options.failFast && diagnostics.length > 0) {

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -1,5 +1,6 @@
 import * as cssTree from "css-tree";
 
+import { getImportSpecifier, isAbsoluteImportUrl, type CssAtruleNode } from "./imports.js";
 import { buildRepresentativeSamples } from "./syntax-samples.js";
 import { collectRegistry } from "./registry.js";
 import {
@@ -51,6 +52,8 @@ interface CssWalkNode {
 
 type CssLocation = NonNullable<ValidationDiagnostic["loc"]>;
 
+const PROPERTY_RULE_DESCRIPTOR_NAMES = Object.freeze(["syntax", "inherits", "initial-value"]);
+
 function toLocation(loc: unknown): ValidationDiagnostic["loc"] {
   if (!loc) {
     return null;
@@ -69,8 +72,110 @@ function registryMap(registry: RegisteredProperty[]): Map<string, RegisteredProp
   return new Map(registry.map((entry) => [entry.name, entry]));
 }
 
+function customPropertySet(properties: Iterable<string>): Set<string> {
+  return new Set([...properties].filter(isCustomPropertyName));
+}
+
 function isCustomPropertyName(propertyName: string): boolean {
   return propertyName.startsWith("--");
+}
+
+function isPropertyRuleDescriptorName(propertyName: string): boolean {
+  return PROPERTY_RULE_DESCRIPTOR_NAMES.includes(propertyName);
+}
+
+function mergeInto(target: Set<string>, source: Iterable<string>): void {
+  for (const value of source) {
+    target.add(value);
+  }
+}
+
+function collectKnownCustomProperties(
+  inputs: ValidationInput[],
+  registryInputs: ValidationInput[],
+  registry: Map<string, RegisteredProperty>,
+  resolveImport?: ResolveImport,
+): Map<string, Set<string>> {
+  const byPath = new Map<string, Set<string>>();
+
+  function collectForInput(input: ValidationInput, activePaths = new Set<string>()): Set<string> {
+    const cached = byPath.get(input.path);
+
+    if (cached) {
+      return cached;
+    }
+
+    const known = new Set<string>();
+    byPath.set(input.path, known);
+
+    if (activePaths.has(input.path)) {
+      return known;
+    }
+
+    activePaths.add(input.path);
+
+    let ast: CssValueAst;
+
+    try {
+      ast = cssTree.parse(input.css, {
+        filename: input.path,
+        positions: true,
+      });
+    } catch {
+      activePaths.delete(input.path);
+      return known;
+    }
+
+    cssTree.walk(ast, {
+      visit: "Declaration",
+      enter(node: CssWalkNode) {
+        const declaration = node as CssDeclarationNode;
+
+        if (isCustomPropertyName(declaration.property)) {
+          known.add(declaration.property);
+        }
+      },
+    });
+
+    for (const node of Array.from(
+      (ast as { children?: ArrayLike<unknown> }).children ?? [],
+    ) as CssAtruleNode[]) {
+      if (node.type !== "Atrule" || node.name !== "import") {
+        continue;
+      }
+
+      const importSpecifier = getImportSpecifier(node);
+
+      if (!importSpecifier || isAbsoluteImportUrl(importSpecifier) || !resolveImport) {
+        continue;
+      }
+
+      const importedInput = resolveImport(importSpecifier, input.path);
+
+      if (!importedInput) {
+        continue;
+      }
+
+      mergeInto(known, collectForInput(importedInput, activePaths));
+    }
+
+    activePaths.delete(input.path);
+    return known;
+  }
+
+  const globalCustomProperties = customPropertySet(registry.keys());
+
+  for (const input of registryInputs) {
+    mergeInto(globalCustomProperties, collectForInput(input));
+  }
+
+  for (const input of inputs) {
+    const visibleProperties = new Set(globalCustomProperties);
+    mergeInto(visibleProperties, collectForInput(input));
+    byPath.set(input.path, visibleProperties);
+  }
+
+  return byPath;
 }
 
 function collectVarFunctions(value: CssValueAst): VarFunctionNode[] {
@@ -252,6 +357,26 @@ function toFallbackDiagnostic(
   };
 }
 
+function toUnresolvedVarDiagnostic(
+  filePath: string,
+  declaration: CssDeclarationNode,
+  propertyName: string,
+  varNode: VarFunctionNode,
+): ValidationDiagnostic {
+  return {
+    code: "incompatible-var-usage",
+    phase: "usage",
+    reason: "unresolved-var-reference",
+    severity: "error",
+    filePath,
+    loc: toLocation(varNode.loc),
+    message: `Custom property ${propertyName} is not defined in the known CSS inputs for this file, and no fallback was provided. This is a static check of the CSS files and imports available to the validator, not a full browser cascade evaluation.`,
+    propertyName,
+    expectedProperty: declaration.property,
+    snippet: cssTree.generate(declaration),
+  };
+}
+
 function toPreciseMultiVarDiagnostic(
   filePath: string,
   declaration: CssDeclarationNode,
@@ -310,8 +435,14 @@ function validateDeclaration(
   filePath: string,
   declaration: CssDeclarationNode,
   registry: Map<string, RegisteredProperty>,
+  knownCustomProperties: Set<string>,
 ): { diagnostics: ValidationDiagnostic[]; skipped: number; validated: number } {
   const diagnostics: ValidationDiagnostic[] = [];
+
+  if (isPropertyRuleDescriptorName(declaration.property)) {
+    return { diagnostics, skipped: 0, validated: 0 };
+  }
+
   const valueToValidate = getDeclarationValueForValidation(declaration);
 
   if (!valueToValidate) {
@@ -363,6 +494,18 @@ function validateDeclaration(
     return { diagnostics, skipped: 1, validated: 0 };
   }
 
+  for (const entry of varMetadata) {
+    if (
+      entry.propertyName &&
+      !knownCustomProperties.has(entry.propertyName) &&
+      getVarFallbackSource(entry.varNode) === null
+    ) {
+      diagnostics.push(
+        toUnresolvedVarDiagnostic(filePath, declaration, entry.propertyName, entry.varNode),
+      );
+    }
+  }
+
   const registeredEntries = varMetadata.filter(
     (
       entry,
@@ -375,7 +518,11 @@ function validateDeclaration(
 
   if (isCustomPropertyName(declaration.property)) {
     if (registeredEntries.length !== varMetadata.length) {
-      return { diagnostics, skipped: 1, validated: 0 };
+      return {
+        diagnostics,
+        skipped: diagnostics.length > 0 ? 0 : 1,
+        validated: 0,
+      };
     }
   }
 
@@ -386,7 +533,11 @@ function validateDeclaration(
 
   // Mixed registered and unregistered var() usages still leave unresolved values in the declaration.
   if (registeredEntries.length !== varMetadata.length) {
-    return { diagnostics, skipped: 1, validated: 0 };
+    return {
+      diagnostics,
+      skipped: diagnostics.length > 0 ? 0 : 1,
+      validated: 0,
+    };
   }
 
   // Universal-syntax registrations compute like unregistered custom properties,
@@ -567,6 +718,12 @@ export function validateFiles(
   });
   const diagnostics = [...registryResult.diagnostics];
   const registry = registryMap(registryResult.registry);
+  const knownCustomPropertiesByPath = collectKnownCustomProperties(
+    inputs,
+    registryInputs,
+    registry,
+    options.resolveImport,
+  );
   let skippedDeclarations = 0;
   let validatedDeclarations = 0;
 
@@ -611,7 +768,14 @@ export function validateFiles(
           return;
         }
 
-        const result = validateDeclaration(input.path, node as CssDeclarationNode, registry);
+        const knownCustomProperties =
+          knownCustomPropertiesByPath.get(input.path) ?? customPropertySet(registry.keys());
+        const result = validateDeclaration(
+          input.path,
+          node as CssDeclarationNode,
+          registry,
+          knownCustomProperties,
+        );
         diagnostics.push(...result.diagnostics);
         skippedDeclarations += result.skipped;
         validatedDeclarations += result.validated;

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -122,12 +122,14 @@ describe("validateFiles", () => {
     expect(result.validatedDeclarations).toBe(1);
   });
 
-  it("ignores unregistered custom properties", () => {
+  it("reports unresolved unregistered custom properties without fallbacks", () => {
     const result = runValidation({
       "/tmp/usage.css": ".card { inline-size: var(--space); }",
     });
 
-    expect(result.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--space");
     expect(result.validatedDeclarations).toBe(0);
   });
 
@@ -374,15 +376,17 @@ describe("validateFiles", () => {
     expect(result.validatedDeclarations).toBe(1);
   });
 
-  it("skips assignment-site validation when var() references are mixed registered and unregistered", () => {
+  it("reports unresolved assignment-site var() references without fallbacks", () => {
     const result = runValidation({
       "/tmp/registry.css":
         '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
       "/tmp/usage.css": ":root { --space: var(--unknown-space); }",
     });
 
-    expect(result.diagnostics).toHaveLength(0);
-    expect(result.skippedDeclarations).toBe(1);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--unknown-space");
+    expect(result.skippedDeclarations).toBe(0);
     expect(result.validatedDeclarations).toBe(0);
   });
 
@@ -567,25 +571,62 @@ describe("validateFiles", () => {
     expect(result.validatedDeclarations).toBe(1);
   });
 
-  it("skips mixed registered and unregistered multi-var() declarations", () => {
+  it("reports unknown no-fallback var() references", () => {
+    const result = runValidation({
+      "/tmp/usage.css": ".card { color: var(--shared-color-white); }",
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
+    expect(result.diagnostics[0]?.phase).toBe("usage");
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--shared-color-white");
+    expect(result.diagnostics[0]?.expectedProperty).toBe("color");
+    expect(result.diagnostics[0]?.message).toContain("known CSS inputs");
+    expect(result.diagnostics[0]?.message).toContain("not a full browser cascade evaluation");
+  });
+
+  it("accepts unknown var() references that provide a fallback", () => {
+    const result = runValidation({
+      "/tmp/usage.css": ".card { color: var(--shared-color-white, white); }",
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it("accepts var() references to custom properties declared in the same file", () => {
+    const result = runValidation({
+      "/tmp/usage.css":
+        ":root { --shared-color-white: white; }\n.card { color: var(--shared-color-white); }",
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports unknown no-fallback var() references in mixed multi-var() declarations", () => {
     const result = runValidation({
       "/tmp/registry.css":
         '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
       "/tmp/usage.css": ".card { margin: var(--space) var(--unknown-gap); }",
     });
 
-    expect(result.diagnostics).toHaveLength(0);
-    expect(result.skippedDeclarations).toBe(1);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--unknown-gap");
+    expect(result.skippedDeclarations).toBe(0);
   });
 
-  it("skips multi-var() declarations when one var() cannot be fully resolved", () => {
+  it("reports unknown no-fallback var() references when one multi-var() cannot be fully resolved", () => {
     const result = runValidation({
       "/tmp/registry.css": SHARED_REGISTRY,
       "/tmp/usage.css": ".card { border: var(--border-width) solid var(--missing-color); }",
     });
 
-    expect(result.diagnostics).toHaveLength(0);
-    expect(result.skippedDeclarations).toBe(1);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--missing-color");
+    expect(result.skippedDeclarations).toBe(0);
     expect(result.validatedDeclarations).toBe(0);
   });
 
@@ -676,6 +717,50 @@ describe("validateFiles", () => {
     expect(result.registry).toHaveLength(1);
     expect(result.registry[0]?.filePath).toBe("/tmp/tokens.css");
     expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("uses imports from validation inputs when checking known custom properties", () => {
+    const cssByPath = {
+      "/tmp/main.css": '@import "./tokens.css";\n.card { color: var(--surface-color); }',
+      "/tmp/tokens.css": ":root { --surface-color: canvas; }",
+    };
+
+    const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      resolveImport: createTestResolver(cssByPath),
+    });
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("uses registry-only inputs when checking known custom properties", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { color: var(--surface-color); }" }],
+      {
+        registryInputs: [
+          {
+            path: "/tmp/tokens.css",
+            css: ":root { --surface-color: canvas; }",
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("reports unknown custom properties missing from the resolved import path", () => {
+    const cssByPath = {
+      "/tmp/main.css": '@import "./tokens.css";\n.card { color: var(--missing-color); }',
+      "/tmp/tokens.css": ":root { --surface-color: canvas; }",
+    };
+
+    const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      resolveImport: createTestResolver(cssByPath),
+    });
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--missing-color");
   });
 
   it("follows nested imports from registry-only inputs", () => {
@@ -774,7 +859,7 @@ describe("validateFiles", () => {
     expect(result.validatedDeclarations).toBe(1);
   });
 
-  it("skips absolute URL imports when assembling the registry", () => {
+  it("skips absolute URL imports when assembling known inputs", () => {
     const result = validateFiles(
       [
         {
@@ -789,12 +874,14 @@ describe("validateFiles", () => {
       },
     );
 
-    expect(result.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--space");
     expect(result.registry).toHaveLength(0);
     expect(result.validatedDeclarations).toBe(0);
   });
 
-  it("skips conditioned imports when assembling the registry", () => {
+  it("skips conditioned imports when assembling known inputs", () => {
     const result = validateFiles(
       [
         {
@@ -809,7 +896,9 @@ describe("validateFiles", () => {
       },
     );
 
-    expect(result.diagnostics).toHaveLength(0);
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--space");
     expect(result.registry).toHaveLength(0);
     expect(result.validatedDeclarations).toBe(0);
   });
@@ -903,13 +992,14 @@ describe("validateFiles", () => {
         expectedProperty?: string;
         message: string;
         propertyName?: string;
+        reason?: string;
         snippet?: string;
       }>;
       skippedDeclarations: number;
       validatedDeclarations: number;
     };
 
-    expect(report.diagnostics).toHaveLength(21);
+    expect(report.diagnostics).toHaveLength(22);
     expect(
       report.diagnostics.some((diagnostic) => diagnostic.code === "invalid-property-registration"),
     ).toBe(true);
@@ -952,6 +1042,13 @@ describe("validateFiles", () => {
         (diagnostic) =>
           diagnostic.snippet === "border:var(--brand-color) solid var(--brand-color)" &&
           diagnostic.message.includes("may be incompatible"),
+      ),
+    ).toBe(true);
+    expect(
+      report.diagnostics.some(
+        (diagnostic) =>
+          diagnostic.reason === "unresolved-var-reference" &&
+          diagnostic.message.includes("not a full browser cascade evaluation"),
       ),
     ).toBe(true);
     expect(report.skippedDeclarations).toBe(0);
@@ -1025,6 +1122,46 @@ describe("validateFiles", () => {
     );
     expect(cliResult.stdout).toContain("inline-size:var(--brand-color)");
   });
+
+  it(
+    "includes unresolved var() diagnostics in CLI human and json output",
+    { timeout: 120000 },
+    () => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+      const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+      const validationPath = path.join(fixtureDir, "component.css");
+
+      writeFileSync(validationPath, ".card { color: var(--missing-color); }\n");
+
+      const humanResult = spawnSync("node", ["packages/cli/dist/cli.js", validationPath], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
+
+      expect(humanResult.status).toBe(1);
+      expect(humanResult.stdout).toContain(`${validationPath}:1:16 incompatible-var-usage`);
+      expect(humanResult.stdout).toContain("Custom property --missing-color is not defined");
+      expect(humanResult.stdout).toContain("not a full browser cascade evaluation");
+      expect(humanResult.stdout).toContain("color:var(--missing-color)");
+
+      const jsonResult = spawnSync(
+        "node",
+        ["packages/cli/dist/cli.js", validationPath, "--format", "json"],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+        },
+      );
+      const report = JSON.parse(jsonResult.stdout) as {
+        diagnostics: Array<{ propertyName?: string; reason?: string; message: string }>;
+      };
+
+      expect(jsonResult.status).toBe(1);
+      expect(report.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+      expect(report.diagnostics[0]?.propertyName).toBe("--missing-color");
+      expect(report.diagnostics[0]?.message).toContain("known CSS inputs");
+    },
+  );
 
   it(
     "limits CLI json output to the first validation failure with --failfast",

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -881,6 +881,28 @@ describe("validateFiles", () => {
     expect(result.validatedDeclarations).toBe(0);
   });
 
+  it("skips protocol-relative URL imports when assembling known inputs", () => {
+    const result = validateFiles(
+      [
+        {
+          path: "/tmp/main.css",
+          css: '@import "//cdn.example.com/tokens.css";\n.card { inline-size: var(--space); }',
+        },
+      ],
+      {
+        resolveImport: () => {
+          throw new Error("protocol-relative imports should be skipped before resolution");
+        },
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[0]?.propertyName).toBe("--space");
+    expect(result.registry).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
   it("skips conditioned imports when assembling known inputs", () => {
     const result = validateFiles(
       [

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -5,7 +5,7 @@ Validate typed CSS custom property registrations and `var()` usage directly in V
 ## Features
 
 - Validates plain CSS documents as you edit.
-- Reports native editor diagnostics for invalid `@property` registrations, incompatible registered custom property assignments, incompatible `var()` usage, unresolved imports, and parse failures.
+- Reports native editor diagnostics for invalid `@property` registrations, incompatible registered custom property assignments, incompatible `var()` usage, unknown no-fallback `var()` references, unresolved imports, and parse failures.
 - Supports shared `@property` registry files through workspace settings.
 - Refreshes registry inputs and open-document diagnostics with one command.
 
@@ -30,6 +30,7 @@ Registry files contribute `@property` registrations and registration diagnostics
 - V1 validates CSS files only.
 - Desktop VS Code-compatible editors are supported; web extension hosts such as vscode.dev and GitHub.dev are out of scope for this version.
 - Embedded HTML style blocks, SCSS, Less, PostCSS, Vue, Svelte, JSX, and TSX are out of scope for this version.
+- Unresolved `var()` diagnostics are static known-inputs checks, not full browser cascade evaluations for a specific DOM element.
 - The extension does not provide autofixes.
 
 ## Packaging And Release

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "css-property-type-validator",
   "displayName": "CSS Property Type Validator",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "description": "Validate typed CSS custom property registrations and var() usage in CSS files.",
   "categories": [
     "Linters",

--- a/packages/vscode/test/suite/extension.test.cts
+++ b/packages/vscode/test/suite/extension.test.cts
@@ -81,6 +81,21 @@ suite("CSS Property Type Validator extension", () => {
     await waitForDiagnostics(document.uri, 0);
   });
 
+  test("reports unresolved var references for open CSS documents", async () => {
+    const componentUri = await writeWorkspaceFile(
+      "unresolved-var-component.css",
+      ".card { color: var(--missing-color); }",
+    );
+    const document = await vscode.workspace.openTextDocument(componentUri);
+
+    await vscode.window.showTextDocument(document);
+
+    const diagnostics = await waitForDiagnostics(document.uri, 1);
+    assert.equal(diagnostics[0]?.source, "CSS Property Type Validator");
+    assert.equal(diagnostics[0]?.code, "unresolved-var-reference");
+    assert.match(diagnostics[0]?.message ?? "", /not a full browser cascade evaluation/);
+  });
+
   test("reports diagnostics when only a registry file is configured", async () => {
     await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     const registryUri = await writeWorkspaceFile(

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "packages/*"
   - "web"
+allowBuilds:
+  "@vscode/vsce-sign": true
+  keytar: true

--- a/web/tests/e2e/validator.e2e.ts
+++ b/web/tests/e2e/validator.e2e.ts
@@ -20,6 +20,10 @@ const VALID_CSS = `@property --space {
   inline-size: var(--space);
 }`;
 
+const UNRESOLVED_CSS = `.card {
+  color: var(--missing-color);
+}`;
+
 async function replaceEditorContents(page: Page, css: string) {
   await page.locator("validator-code-editor.js-input-editor").evaluate((editor, value) => {
     const codeEditor = editor as HTMLElement & { value: string };
@@ -103,6 +107,15 @@ test("switches diagnostics to pretty JSON", async ({ page }) => {
 
   await expect(page.getByText('"diagnostics": [')).toBeVisible();
   await expect(page.getByText('"code": "incompatible-var-usage"')).toBeVisible();
+});
+
+test("shows unresolved var diagnostics in the browser output", async ({ page }) => {
+  await page.goto("/");
+  await replaceEditorContents(page, UNRESOLVED_CSS);
+  await page.getByRole("button", { name: "Validate" }).click();
+
+  await expect(page.getByText("Custom property --missing-color is not defined")).toBeVisible();
+  await expect(page.getByText("not a full browser cascade evaluation")).toBeVisible();
 });
 
 test("shows the success state for valid CSS", async ({ page }) => {


### PR DESCRIPTION
## Summary
- report unknown no-fallback var() references from known CSS inputs
- collect authored custom properties from same-file CSS, resolved imports, registry inputs, and @property registrations
- document the static known-inputs limitation and bump relevant package versions
- allow approved dependency builds in pnpm workspace config

## Verification
- pnpm run format:check
- pnpm run typecheck
- pnpm test
- pnpm run lint
- pnpm run build
- pnpm run test:e2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detection for unresolved CSS `var()` references without fallbacks; now reports when custom properties are undefined.
  * Improved `@import` handling during validation to follow local unconditioned imports for accurate property resolution.

* **Documentation**
  * Updated package READMEs to document new validation capabilities and clarify that unresolved diagnostics are static checks, not full browser cascade evaluation.

* **Chores**
  * Version bumps: CLI 0.7.0, Core 0.11.0, VS Code extension 0.2.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->