### PR TITLE
Make unknown custom property checks opt in and seed them from token files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # CSS Property Type Validator
 
-Validate CSS custom property registrations declared with `@property`, then check whether registered custom properties are used compatibly through `var()` and whether referenced custom properties are known to the validator.
+Validate CSS custom property registrations declared with `@property`, then check whether registered custom properties are used compatibly through `var()`.
 
 Use it when your design tokens or component styles rely on typed custom properties and you want CI to catch mistakes such as a color token being used for `inline-size`, or a length token being assigned an invalid value.
 
@@ -12,7 +12,7 @@ Use it when your design tokens or component styles rely on typed custom properti
 - Checks registered `var()` usages against the consuming CSS property
 - Checks simple `var()` fallback branches against the consuming CSS property
 - Validates authored values assigned directly to registered custom properties
-- Reports unknown no-fallback `var()` references from known CSS inputs
+- Optionally reports unknown no-fallback `var()` references from configured known custom property inputs
 - Ignores unknown custom properties when that `var()` call provides a fallback
 - Skips ambiguous cases conservatively to avoid false positives
 
@@ -47,6 +47,7 @@ css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 css-property-type-validator "src/tokens/**/*.css" --registry-only
+css-property-type-validator "src/**/*.css" --check-unknown-custom-properties --tokens "src/tokens/**/*.css"
 css-property-type-validator "src/**/*.css" --failfast
 ```
 
@@ -63,6 +64,16 @@ css-property-type-validator "src/tokens/**/*.css" --registry-only
 ```
 
 Registry-only files still report parse errors and invalid `@property` registrations.
+
+Use `--check-unknown-custom-properties` to opt in to static no-fallback `var()` reference checks. Use `--tokens` with that flag to seed known custom property names from one or more token files without validating ordinary declarations from those files:
+
+```bash
+css-property-type-validator "src/components/**/*.css" \
+  --check-unknown-custom-properties \
+  --tokens "src/tokens/**/*.css"
+```
+
+The CLI prints a warning when unresolved checks are enabled without `--tokens`, and when `--tokens` is provided without enabling unresolved checks.
 
 By default, the CLI collects every validation failure it can find and reports the full result set.
 Use `--failfast` when you want it to stop after the first validation failure, including
@@ -133,7 +144,11 @@ The validator assembles one registry from the full set of validation inputs, reg
 
 When a resolver is available, the core follows local unconditioned `@import` rules while assembling the registry and known custom property inputs. The CLI provides a resolver for relative and root-relative local CSS imports. Remote imports and conditioned imports are intentionally out of scope for now.
 
-Unresolved `var()` diagnostics are static known-inputs checks. They report `var(--token)` when `--token` is absent from known files/imports/registry inputs and no fallback is provided, but they do not attempt a full browser cascade evaluation for a specific DOM element.
+Unresolved `var()` diagnostics are opt-in static known-inputs checks. They report `var(--token)` when `--token` is absent from known files/imports/registry/token inputs and no fallback is provided, but they do not attempt a full browser cascade evaluation for a specific DOM element.
+
+Consumers should follow the same pattern as the CLI, web app, and VS Code extension: expose the unresolved-reference check as off by default, and expose token-file configuration beside it so projects can provide their real custom property source of truth.
+
+The browser UI accepts one or more selected CSS token files. Recursive folder selection is not exposed because directory upload is not consistently standardized across browsers.
 
 Compatibility checks are conservative:
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -2,7 +2,7 @@
 
 Command-line interface for CSS Property Type Validator.
 
-Use it locally or in CI to validate CSS `@property` registrations, registered `var()` usage, unresolved no-fallback `var()` references from known CSS inputs, simple fallback branches, and authored assignments to registered custom properties.
+Use it locally or in CI to validate CSS `@property` registrations, registered `var()` usage, simple fallback branches, and authored assignments to registered custom properties. Static unresolved no-fallback `var()` checks are available as an opt-in.
 
 ## Install
 
@@ -23,6 +23,7 @@ css-property-type-validator "src/**/*.css"
 css-property-type-validator "src/**/*.css" --format json
 css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 css-property-type-validator "src/tokens/**/*.css" --registry-only
+css-property-type-validator "src/**/*.css" --check-unknown-custom-properties --tokens "src/tokens/**/*.css"
 css-property-type-validator "src/**/*.css" --failfast
 ```
 
@@ -36,7 +37,9 @@ css-property-type-validator "src/**/*.css" \
 
 The CLI follows local unconditioned `@import` rules while assembling the registry and known custom property inputs, including relative and root-relative imports. Remote and conditioned imports are skipped.
 
-Unresolved `var()` diagnostics are static known-inputs checks. They report `var(--token)` when `--token` is absent from known files/imports/registry inputs and no fallback is provided, but they do not attempt a full browser cascade evaluation for a specific DOM element.
+Unresolved `var()` diagnostics are static known-inputs checks enabled with `--check-unknown-custom-properties`. Use `--tokens` to seed known custom property names from token files without validating ordinary declarations from those files. These diagnostics do not attempt a full browser cascade evaluation for a specific DOM element.
+
+The CLI prints a warning when unresolved checks are enabled without `--tokens`, and when `--tokens` is provided without enabling unresolved checks.
 
 By default, the CLI collects and reports all validation failures. Use `--failfast` to stop after the first validation failure, whether it comes from registry assembly, `@property` validation, or declaration usage validation. Exit codes and human/JSON output formats are unchanged.
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -18,6 +18,15 @@ import type {
   ValidationInput,
 } from "@schalkneethling/css-property-type-validator-core";
 
+interface CliOptions {
+  checkUnknownCustomProperties: boolean;
+  failfast: boolean;
+  format: OutputFormat;
+  registry: string[];
+  registryOnly: boolean;
+  tokens: string[];
+}
+
 async function loadInputs(patterns: string[]): Promise<ValidationInput[]> {
   const filePaths = new Set<string>();
 
@@ -75,6 +84,25 @@ function resolveOutputFormat(format: string): OutputFormat {
   return format === "json" ? "json" : "human";
 }
 
+function writeUnknownCustomPropertyConfigurationWarnings(options: CliOptions): void {
+  if (options.checkUnknownCustomProperties && options.tokens.length === 0) {
+    process.stderr.write(
+      "Warning: --check-unknown-custom-properties is enabled without --tokens. Configure one or more token files to avoid false positives from project-wide custom properties outside the validation/import path.\n",
+    );
+  }
+
+  if (!options.checkUnknownCustomProperties && options.tokens.length > 0) {
+    process.stderr.write(
+      "Warning: --tokens is ignored unless --check-unknown-custom-properties is enabled.\n",
+    );
+  }
+}
+
+async function loadKnownCustomPropertyInputs(options: CliOptions): Promise<ValidationInput[]> {
+  writeUnknownCustomPropertyConfigurationWarnings(options);
+  return options.checkUnknownCustomProperties ? loadInputs(options.tokens) : [];
+}
+
 async function main(): Promise<void> {
   const program = new Command();
 
@@ -85,8 +113,19 @@ async function main(): Promise<void> {
     .option("-f, --format <format>", "output format: human or json", "human")
     .option("--failfast", "stop after the first validation failure", false)
     .option(
+      "--check-unknown-custom-properties",
+      "report no-fallback var() references that are missing from known custom property inputs",
+      false,
+    )
+    .option(
       "-r, --registry <pattern>",
       "CSS file or glob pattern to use for shared @property registrations",
+      (value: string, previous: string[] = []) => [...previous, value],
+      [],
+    )
+    .option(
+      "--tokens <pattern>",
+      "CSS file or glob pattern to use as known custom property token sources",
       (value: string, previous: string[] = []) => [...previous, value],
       [],
     )
@@ -95,75 +134,68 @@ async function main(): Promise<void> {
       "validate @property registrations from the provided input patterns without validating ordinary declarations",
       false,
     )
-    .action(
-      async (
-        patterns: string[],
-        options: {
-          failfast: boolean;
-          format: OutputFormat;
-          registry: string[];
-          registryOnly: boolean;
-        },
-      ) => {
-        const format = resolveOutputFormat(options.format);
+    .action(async (patterns: string[], options: CliOptions) => {
+      const format = resolveOutputFormat(options.format);
 
-        if (options.registryOnly) {
-          if (patterns.length === 0) {
-            process.stderr.write(
-              "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
-            );
-            process.exitCode = 2;
-            return;
-          }
-
-          const registryInputs = await loadInputs(patterns);
-
-          if (registryInputs.length === 0) {
-            process.stderr.write(
-              "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
-            );
-            process.exitCode = 2;
-            return;
-          }
-
-          const additionalRegistryInputs = await loadRegistryInputs(
-            options.registry,
-            registryInputs,
-          );
-          const result = validateFiles([], {
-            failFast: options.failfast,
-            registryInputs: [...registryInputs, ...additionalRegistryInputs],
-            resolveImport: createImportResolver(process.cwd()),
-          });
-          const output = formatValidationResult(result, format);
-
-          process.stdout.write(`${output}\n`);
-          process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
-          return;
-        }
-
-        const inputs = await loadInputs(patterns);
-
-        if (inputs.length === 0) {
+      if (options.registryOnly) {
+        if (patterns.length === 0) {
           process.stderr.write(
-            "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.\n",
+            "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
           );
           process.exitCode = 2;
           return;
         }
 
-        const registryInputs = await loadRegistryInputs(options.registry, inputs);
-        const result = validateFiles(inputs, {
+        const registryInputs = await loadInputs(patterns);
+
+        if (registryInputs.length === 0) {
+          process.stderr.write(
+            "No CSS files matched the registration-only patterns. Pass one or more CSS files or glob patterns to --registry-only.\n",
+          );
+          process.exitCode = 2;
+          return;
+        }
+
+        const additionalRegistryInputs = await loadRegistryInputs(options.registry, registryInputs);
+        const knownCustomPropertyInputs = await loadKnownCustomPropertyInputs(options);
+        const result = validateFiles([], {
+          checkUnresolvedCustomProperties: options.checkUnknownCustomProperties,
           failFast: options.failfast,
-          registryInputs,
+          knownCustomPropertyInputs,
+          registryInputs: [...registryInputs, ...additionalRegistryInputs],
           resolveImport: createImportResolver(process.cwd()),
         });
         const output = formatValidationResult(result, format);
 
         process.stdout.write(`${output}\n`);
         process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
-      },
-    );
+        return;
+      }
+
+      const inputs = await loadInputs(patterns);
+
+      if (inputs.length === 0) {
+        process.stderr.write(
+          "No CSS files matched the validation patterns. Files passed via --registry are registration sources only.\n",
+        );
+        process.exitCode = 2;
+        return;
+      }
+
+      const registryInputs = await loadRegistryInputs(options.registry, inputs);
+      const knownCustomPropertyInputs = await loadKnownCustomPropertyInputs(options);
+      const result = validateFiles(inputs, {
+        checkUnresolvedCustomProperties: options.checkUnknownCustomProperties,
+        failFast: options.failfast,
+        knownCustomPropertyInputs,
+        registryInputs,
+        resolveImport: createImportResolver(process.cwd()),
+      });
+      const output = formatValidationResult(result, format);
+
+      process.stdout.write(`${output}\n`);
+      process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
+    });
 
   await program.parseAsync(process.argv);
 }

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -2,7 +2,7 @@
 
 Core validation engine for CSS Property Type Validator.
 
-It reads CSS `@property` registrations, builds a registry of typed custom properties, validates registration descriptors, checks compatible `var()` usage against consuming CSS properties, reports unresolved no-fallback `var()` references from known CSS inputs, validates simple fallback branches, and checks authored assignments to registered custom properties.
+It reads CSS `@property` registrations, builds a registry of typed custom properties, validates registration descriptors, checks compatible `var()` usage against consuming CSS properties, optionally reports unresolved no-fallback `var()` references from known custom property inputs, validates simple fallback branches, and checks authored assignments to registered custom properties.
 
 ## Install
 
@@ -23,6 +23,13 @@ const result = validateFiles(
     },
   ],
   {
+    checkUnresolvedCustomProperties: true,
+    knownCustomPropertyInputs: [
+      {
+        path: "project-tokens.css",
+        css: ":root { --brand-color: rebeccapurple; }",
+      },
+    ],
     registryInputs: [
       {
         path: "tokens.css",
@@ -83,7 +90,7 @@ type ValidationDiagnostic = {
 
 `code` is the broad diagnostic category, while `phase` and `reason` are intended for rule mapping, editor diagnostics, filtering, and stable automation. Existing fields such as `propertyName`, `registeredSyntax`, and `expectedProperty` remain available for integrations that already consume them.
 
-Provide `resolveImport` when registry assembly and known custom property checks should follow local unconditioned imports:
+Provide `resolveImport` when registry assembly and opt-in known custom property checks should follow local unconditioned imports:
 
 ```ts
 const result = validateFiles(inputs, {
@@ -97,8 +104,12 @@ const result = validateFiles(inputs, {
 ## Notes
 
 - `registryInputs` contribute registrations and registration diagnostics without validating ordinary declarations from those files.
-- `unresolved-var-reference` is a static known-inputs diagnostic. It reports `var(--token)` when `--token` is absent from known files/imports/registry inputs and no fallback is provided; it does not attempt a full browser cascade evaluation for a specific DOM element.
+- `checkUnresolvedCustomProperties` defaults to `false`; integrations should expose it as opt-in.
+- `knownCustomPropertyInputs` seed the known custom property set for `unresolved-var-reference` without becoming validation targets.
+- If the same file is also present in the validation inputs, its ordinary declarations are still validated as part of the normal validation path.
+- `unresolved-var-reference` is a static known-inputs diagnostic. When enabled, it reports `var(--token)` when `--token` is absent from known files/imports/registry/token inputs and no fallback is provided; it does not attempt a full browser cascade evaluation for a specific DOM element.
 - Unknown custom properties with fallbacks, such as `var(--token, red)`, do not report `unresolved-var-reference`.
+- Other consumers should follow the CLI, web, and VS Code pattern: keep unresolved checks off by default and pair the opt-in with token-file configuration.
 - Ambiguous cases are skipped conservatively to avoid false positives.
 - Remote and conditioned imports are out of scope unless a future validation model can handle them safely.
 

--- a/packages/core/src/validate.ts
+++ b/packages/core/src/validate.ts
@@ -28,7 +28,9 @@ import type {
 } from "./var-substitution.js";
 
 export interface ValidateFilesOptions {
+  checkUnresolvedCustomProperties?: boolean;
   failFast?: boolean;
+  knownCustomPropertyInputs?: ValidationInput[];
   registryInputs?: ValidationInput[];
   resolveImport?: ResolveImport;
 }
@@ -135,14 +137,38 @@ function parseStylesheet(
 
 function collectKnownCustomProperties(
   inputs: ValidationInput[],
+  knownCustomPropertyInputs: ValidationInput[],
   registryInputs: ValidationInput[],
   registry: Map<string, RegisteredProperty>,
+  diagnostics: ValidationDiagnostic[],
   parsedAstByPath: Map<string, ParsedStylesheetResult>,
   resolveImport?: ResolveImport,
 ): Map<string, Set<string>> {
   const byPath = new Map<string, Set<string>>();
+  const reportedKnownInputParsePaths = new Set<string>();
 
-  function collectForInput(input: ValidationInput, activePaths = new Set<string>()): Set<string> {
+  function reportKnownInputParseFailure(input: ValidationInput, error: Error): void {
+    if (reportedKnownInputParsePaths.has(input.path)) {
+      return;
+    }
+
+    reportedKnownInputParsePaths.add(input.path);
+    diagnostics.push({
+      code: "unparseable-stylesheet",
+      phase: "parse",
+      reason: "unparseable-css",
+      severity: "error",
+      filePath: input.path,
+      loc: null,
+      message: `Could not parse known custom property input ${input.path}: ${error.message}`,
+    });
+  }
+
+  function collectForInput(
+    input: ValidationInput,
+    activePaths = new Set<string>(),
+    reportParseFailures = false,
+  ): Set<string> {
     const cached = byPath.get(input.path);
 
     if (cached) {
@@ -161,6 +187,10 @@ function collectKnownCustomProperties(
     const parsed = parseStylesheet(input, parsedAstByPath);
 
     if (!parsed.ast) {
+      if (reportParseFailures) {
+        reportKnownInputParseFailure(input, parsed.error);
+      }
+
       activePaths.delete(input.path);
       return known;
     }
@@ -193,7 +223,7 @@ function collectKnownCustomProperties(
         continue;
       }
 
-      mergeInto(known, collectForInput(importedInput, activePaths));
+      mergeInto(known, collectForInput(importedInput, activePaths, reportParseFailures));
     }
 
     activePaths.delete(input.path);
@@ -201,6 +231,10 @@ function collectKnownCustomProperties(
   }
 
   const globalCustomProperties = customPropertySet(registry.keys());
+
+  for (const input of knownCustomPropertyInputs) {
+    mergeInto(globalCustomProperties, collectForInput(input, new Set<string>(), true));
+  }
 
   for (const input of registryInputs) {
     mergeInto(globalCustomProperties, collectForInput(input));
@@ -399,6 +433,7 @@ function toUnresolvedVarDiagnostic(
   declaration: CssDeclarationNode,
   propertyName: string,
   varNode: VarFunctionNode,
+  knownSourceDescription: string,
 ): ValidationDiagnostic {
   return {
     code: "incompatible-var-usage",
@@ -407,7 +442,7 @@ function toUnresolvedVarDiagnostic(
     severity: "error",
     filePath,
     loc: toLocation(varNode.loc),
-    message: `Custom property ${propertyName} is not defined in the known CSS inputs for this file, and no fallback was provided. This is a static check of the CSS files and imports available to the validator, not a full browser cascade evaluation.`,
+    message: `Custom property ${propertyName} is not defined in the ${knownSourceDescription} for this file, and no fallback was provided. This is a static check of the CSS files and imports available to the validator, not a full browser cascade evaluation.`,
     propertyName,
     expectedProperty: declaration.property,
     snippet: cssTree.generate(declaration),
@@ -473,6 +508,10 @@ function validateDeclaration(
   declaration: CssDeclarationNode,
   registry: Map<string, RegisteredProperty>,
   knownCustomProperties: Set<string>,
+  options: {
+    checkUnresolvedCustomProperties: boolean;
+    knownSourceDescription: string;
+  },
 ): { diagnostics: ValidationDiagnostic[]; skipped: number; validated: number } {
   const diagnostics: ValidationDiagnostic[] = [];
 
@@ -533,12 +572,19 @@ function validateDeclaration(
 
   for (const entry of varMetadata) {
     if (
+      options.checkUnresolvedCustomProperties &&
       entry.propertyName &&
       !knownCustomProperties.has(entry.propertyName) &&
       getVarFallbackSource(entry.varNode) === null
     ) {
       diagnostics.push(
-        toUnresolvedVarDiagnostic(filePath, declaration, entry.propertyName, entry.varNode),
+        toUnresolvedVarDiagnostic(
+          filePath,
+          declaration,
+          entry.propertyName,
+          entry.varNode,
+          options.knownSourceDescription,
+        ),
       );
     }
   }
@@ -737,6 +783,12 @@ export function validateFiles(
   options: ValidateFilesOptions = {},
 ): ValidationResult {
   const registryInputs = options.registryInputs ?? [];
+  const knownCustomPropertyInputs = options.knownCustomPropertyInputs ?? [];
+  const checkUnresolvedCustomProperties = options.checkUnresolvedCustomProperties ?? false;
+  const knownSourceDescription =
+    knownCustomPropertyInputs.length > 0
+      ? "configured known custom property inputs"
+      : "known CSS inputs";
   const registrySources = [...inputs];
   const seenRegistryPaths = new Set(inputs.map((input) => input.path));
 
@@ -768,13 +820,26 @@ export function validateFiles(
   }
 
   const parsedAstByPath = new Map<string, ParsedStylesheetResult>();
-  const knownCustomPropertiesByPath = collectKnownCustomProperties(
-    inputs,
-    registryInputs,
-    registry,
-    parsedAstByPath,
-    options.resolveImport,
-  );
+  const knownCustomPropertiesByPath = checkUnresolvedCustomProperties
+    ? collectKnownCustomProperties(
+        inputs,
+        knownCustomPropertyInputs,
+        registryInputs,
+        registry,
+        diagnostics,
+        parsedAstByPath,
+        options.resolveImport,
+      )
+    : new Map<string, Set<string>>();
+
+  if (options.failFast && diagnostics.length > 0) {
+    return {
+      diagnostics,
+      registry: registryResult.registry,
+      skippedDeclarations,
+      validatedDeclarations,
+    };
+  }
 
   for (const input of inputs) {
     const parsed = parseStylesheet(input, parsedAstByPath);
@@ -810,6 +875,10 @@ export function validateFiles(
           node as CssDeclarationNode,
           registry,
           knownCustomProperties,
+          {
+            checkUnresolvedCustomProperties,
+            knownSourceDescription,
+          },
         );
         diagnostics.push(...result.diagnostics);
         skippedDeclarations += result.skipped;

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -6,7 +6,7 @@ import { pathToFileURL } from "node:url";
 
 import { describe, expect, it } from "vitest";
 
-import { validateFiles } from "../src/index.js";
+import { validateFiles, type ValidateFilesOptions } from "../src/index.js";
 
 const SHARED_REGISTRY = [
   '@property --space-sm { syntax: "<length>"; inherits: false; initial-value: 4px; }',
@@ -15,12 +15,13 @@ const SHARED_REGISTRY = [
   '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
 ].join("\n");
 
-function runValidation(cssByPath: Record<string, string>) {
+function runValidation(cssByPath: Record<string, string>, options: ValidateFilesOptions = {}) {
   return validateFiles(
     Object.entries(cssByPath).map(([path, css]) => ({
       path,
       css,
     })),
+    options,
   );
 }
 
@@ -122,10 +123,22 @@ describe("validateFiles", () => {
     expect(result.validatedDeclarations).toBe(1);
   });
 
-  it("reports unresolved unregistered custom properties without fallbacks", () => {
+  it("ignores unresolved unregistered custom properties by default", () => {
     const result = runValidation({
       "/tmp/usage.css": ".card { inline-size: var(--space); }",
     });
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it("reports unresolved unregistered custom properties without fallbacks when enabled", () => {
+    const result = runValidation(
+      {
+        "/tmp/usage.css": ".card { inline-size: var(--space); }",
+      },
+      { checkUnresolvedCustomProperties: true },
+    );
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
@@ -377,11 +390,14 @@ describe("validateFiles", () => {
   });
 
   it("reports unresolved assignment-site var() references without fallbacks", () => {
-    const result = runValidation({
-      "/tmp/registry.css":
-        '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
-      "/tmp/usage.css": ":root { --space: var(--unknown-space); }",
-    });
+    const result = runValidation(
+      {
+        "/tmp/registry.css":
+          '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+        "/tmp/usage.css": ":root { --space: var(--unknown-space); }",
+      },
+      { checkUnresolvedCustomProperties: true },
+    );
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
@@ -572,9 +588,12 @@ describe("validateFiles", () => {
   });
 
   it("reports unknown no-fallback var() references", () => {
-    const result = runValidation({
-      "/tmp/usage.css": ".card { color: var(--shared-color-white); }",
-    });
+    const result = runValidation(
+      {
+        "/tmp/usage.css": ".card { color: var(--shared-color-white); }",
+      },
+      { checkUnresolvedCustomProperties: true },
+    );
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.code).toBe("incompatible-var-usage");
@@ -605,11 +624,14 @@ describe("validateFiles", () => {
   });
 
   it("reports unknown no-fallback var() references in mixed multi-var() declarations", () => {
-    const result = runValidation({
-      "/tmp/registry.css":
-        '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
-      "/tmp/usage.css": ".card { margin: var(--space) var(--unknown-gap); }",
-    });
+    const result = runValidation(
+      {
+        "/tmp/registry.css":
+          '@property --space { syntax: "<length>"; inherits: false; initial-value: 0px; }',
+        "/tmp/usage.css": ".card { margin: var(--space) var(--unknown-gap); }",
+      },
+      { checkUnresolvedCustomProperties: true },
+    );
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
@@ -618,10 +640,13 @@ describe("validateFiles", () => {
   });
 
   it("reports unknown no-fallback var() references when one multi-var() cannot be fully resolved", () => {
-    const result = runValidation({
-      "/tmp/registry.css": SHARED_REGISTRY,
-      "/tmp/usage.css": ".card { border: var(--border-width) solid var(--missing-color); }",
-    });
+    const result = runValidation(
+      {
+        "/tmp/registry.css": SHARED_REGISTRY,
+        "/tmp/usage.css": ".card { border: var(--border-width) solid var(--missing-color); }",
+      },
+      { checkUnresolvedCustomProperties: true },
+    );
 
     expect(result.diagnostics).toHaveLength(1);
     expect(result.diagnostics[0]?.reason).toBe("unresolved-var-reference");
@@ -710,6 +735,7 @@ describe("validateFiles", () => {
     };
 
     const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      checkUnresolvedCustomProperties: true,
       resolveImport: createTestResolver(cssByPath),
     });
 
@@ -736,6 +762,7 @@ describe("validateFiles", () => {
     const result = validateFiles(
       [{ path: "/tmp/component.css", css: ".card { color: var(--surface-color); }" }],
       {
+        checkUnresolvedCustomProperties: true,
         registryInputs: [
           {
             path: "/tmp/tokens.css",
@@ -748,6 +775,144 @@ describe("validateFiles", () => {
     expect(result.diagnostics).toHaveLength(0);
   });
 
+  it("uses configured token inputs when checking known custom properties", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { color: var(--surface-color); }" }],
+      {
+        checkUnresolvedCustomProperties: true,
+        knownCustomPropertyInputs: [
+          {
+            path: "/tmp/tokens.css",
+            css: ":root { --surface-color: canvas; }",
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it("describes configured token inputs in unresolved diagnostics", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { color: var(--missing-color); }" }],
+      {
+        checkUnresolvedCustomProperties: true,
+        knownCustomPropertyInputs: [
+          {
+            path: "/tmp/tokens.css",
+            css: ":root { --surface-color: canvas; }",
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.message).toContain("configured known custom property inputs");
+  });
+
+  it("reports parse failures from configured token inputs", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { color: var(--surface-color); }" }],
+      {
+        checkUnresolvedCustomProperties: true,
+        knownCustomPropertyInputs: [
+          {
+            path: "/tmp/tokens.css",
+            css: null as unknown as string,
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(2);
+    expect(result.diagnostics[0]?.code).toBe("unparseable-stylesheet");
+    expect(result.diagnostics[0]?.filePath).toBe("/tmp/tokens.css");
+    expect(result.diagnostics[0]?.message).toContain("known custom property input");
+    expect(result.diagnostics[1]?.reason).toBe("unresolved-var-reference");
+    expect(result.diagnostics[1]?.propertyName).toBe("--surface-color");
+  });
+
+  it("does not validate ordinary declarations from configured token-only inputs", () => {
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: ".card { color: var(--surface-color); }" }],
+      {
+        checkUnresolvedCustomProperties: true,
+        knownCustomPropertyInputs: [
+          {
+            path: "/tmp/tokens.css",
+            css: ".tokens { inline-size: var(--missing-token); --surface-color: canvas; }",
+          },
+        ],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
+  it("validates ordinary declarations when a configured token input is also a validation input", () => {
+    const tokenInput = {
+      path: "/tmp/tokens.css",
+      css: [
+        '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: transparent; }',
+        ".tokens { inline-size: var(--brand-color); --surface-color: canvas; }",
+      ].join("\n"),
+    };
+
+    const result = validateFiles(
+      [tokenInput, { path: "/tmp/component.css", css: ".card { color: var(--surface-color); }" }],
+      {
+        checkUnresolvedCustomProperties: true,
+        knownCustomPropertyInputs: [tokenInput],
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(1);
+    expect(result.diagnostics[0]?.reason).toBe("incompatible-var-substitution");
+    expect(result.diagnostics[0]?.filePath).toBe("/tmp/tokens.css");
+    expect(result.validatedDeclarations).toBe(1);
+  });
+
+  it("follows nested imports from configured token inputs", () => {
+    const cssByPath = {
+      "/tmp/component.css": ".card { color: var(--surface-color); }",
+      "/tmp/tokens.css": '@import "./nested.css";\n:root { --brand-color: rebeccapurple; }',
+      "/tmp/nested.css": ":root { --surface-color: canvas; }",
+    };
+
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: cssByPath["/tmp/component.css"] }],
+      {
+        checkUnresolvedCustomProperties: true,
+        knownCustomPropertyInputs: [{ path: "/tmp/tokens.css", css: cssByPath["/tmp/tokens.css"] }],
+        resolveImport: createTestResolver(cssByPath),
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("handles cyclic token input imports without duplicate validation work", () => {
+    const cssByPath = {
+      "/tmp/component.css": ".card { color: var(--surface-color); }",
+      "/tmp/a.css": '@import "./b.css";\n:root { --surface-color: canvas; }',
+      "/tmp/b.css": '@import "./a.css";\n:root { --brand-color: rebeccapurple; }',
+    };
+
+    const result = validateFiles(
+      [{ path: "/tmp/component.css", css: cssByPath["/tmp/component.css"] }],
+      {
+        checkUnresolvedCustomProperties: true,
+        knownCustomPropertyInputs: [{ path: "/tmp/a.css", css: cssByPath["/tmp/a.css"] }],
+        resolveImport: createTestResolver(cssByPath),
+      },
+    );
+
+    expect(result.diagnostics).toHaveLength(0);
+    expect(result.validatedDeclarations).toBe(0);
+  });
+
   it("reports unknown custom properties missing from the resolved import path", () => {
     const cssByPath = {
       "/tmp/main.css": '@import "./tokens.css";\n.card { color: var(--missing-color); }',
@@ -755,6 +920,7 @@ describe("validateFiles", () => {
     };
 
     const result = validateFiles([{ path: "/tmp/main.css", css: cssByPath["/tmp/main.css"] }], {
+      checkUnresolvedCustomProperties: true,
       resolveImport: createTestResolver(cssByPath),
     });
 
@@ -868,6 +1034,7 @@ describe("validateFiles", () => {
         },
       ],
       {
+        checkUnresolvedCustomProperties: true,
         resolveImport: () => {
           throw new Error("remote imports should be skipped before resolution");
         },
@@ -890,6 +1057,7 @@ describe("validateFiles", () => {
         },
       ],
       {
+        checkUnresolvedCustomProperties: true,
         resolveImport: () => {
           throw new Error("protocol-relative imports should be skipped before resolution");
         },
@@ -912,6 +1080,7 @@ describe("validateFiles", () => {
         },
       ],
       {
+        checkUnresolvedCustomProperties: true,
         resolveImport: () => {
           throw new Error("conditioned imports should be skipped before resolution");
         },
@@ -999,7 +1168,13 @@ describe("validateFiles", () => {
 
     const cliResult = spawnSync(
       "node",
-      ["packages/cli/dist/cli.js", "fixtures/imports/main.css", "--format", "json"],
+      [
+        "packages/cli/dist/cli.js",
+        "fixtures/imports/main.css",
+        "--format",
+        "json",
+        "--check-unknown-custom-properties",
+      ],
       {
         cwd: repoRoot,
         encoding: "utf8",
@@ -1088,6 +1263,8 @@ describe("validateFiles", () => {
     expect(cliResult.stdout).toContain("--format");
     expect(cliResult.stdout).toContain("--registry");
     expect(cliResult.stdout).toContain("--registry-only");
+    expect(cliResult.stdout).toContain("--tokens");
+    expect(cliResult.stdout).toContain("--check-unknown-custom-properties");
     expect(cliResult.stdout).toContain("--failfast");
   });
 
@@ -1155,12 +1332,19 @@ describe("validateFiles", () => {
 
       writeFileSync(validationPath, ".card { color: var(--missing-color); }\n");
 
-      const humanResult = spawnSync("node", ["packages/cli/dist/cli.js", validationPath], {
-        cwd: repoRoot,
-        encoding: "utf8",
-      });
+      const humanResult = spawnSync(
+        "node",
+        ["packages/cli/dist/cli.js", validationPath, "--check-unknown-custom-properties"],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+        },
+      );
 
       expect(humanResult.status).toBe(1);
+      expect(humanResult.stderr).toContain(
+        "Warning: --check-unknown-custom-properties is enabled without --tokens.",
+      );
       expect(humanResult.stdout).toContain(`${validationPath}:1:16 incompatible-var-usage`);
       expect(humanResult.stdout).toContain("Custom property --missing-color is not defined");
       expect(humanResult.stdout).toContain("not a full browser cascade evaluation");
@@ -1168,7 +1352,13 @@ describe("validateFiles", () => {
 
       const jsonResult = spawnSync(
         "node",
-        ["packages/cli/dist/cli.js", validationPath, "--format", "json"],
+        [
+          "packages/cli/dist/cli.js",
+          validationPath,
+          "--format",
+          "json",
+          "--check-unknown-custom-properties",
+        ],
         {
           cwd: repoRoot,
           encoding: "utf8",
@@ -1179,9 +1369,100 @@ describe("validateFiles", () => {
       };
 
       expect(jsonResult.status).toBe(1);
+      expect(jsonResult.stderr).toContain(
+        "Warning: --check-unknown-custom-properties is enabled without --tokens.",
+      );
       expect(report.diagnostics[0]?.reason).toBe("unresolved-var-reference");
       expect(report.diagnostics[0]?.propertyName).toBe("--missing-color");
       expect(report.diagnostics[0]?.message).toContain("known CSS inputs");
+    },
+  );
+
+  it(
+    "does not include unresolved var() diagnostics in CLI output by default",
+    { timeout: 120000 },
+    () => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+      const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+      const validationPath = path.join(fixtureDir, "component.css");
+
+      writeFileSync(validationPath, ".card { color: var(--missing-color); }\n");
+
+      const cliResult = spawnSync("node", ["packages/cli/dist/cli.js", validationPath], {
+        cwd: repoRoot,
+        encoding: "utf8",
+      });
+
+      expect(cliResult.status).toBe(0);
+      expect(cliResult.stdout.trim()).toBe("No validation issues found.");
+    },
+  );
+
+  it("uses CLI token files for unknown custom property checks", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const validationPath = path.join(fixtureDir, "component.css");
+    const tokenPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(validationPath, ".card { color: var(--surface-color); }\n");
+    writeFileSync(tokenPath, ":root { --surface-color: canvas; }\n");
+
+    const cliResult = spawnSync(
+      "node",
+      [
+        "packages/cli/dist/cli.js",
+        validationPath,
+        "--check-unknown-custom-properties",
+        "--tokens",
+        tokenPath,
+        "--format",
+        "json",
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    const report = JSON.parse(cliResult.stdout) as {
+      diagnostics: Array<{ code: string }>;
+      validatedDeclarations: number;
+    };
+
+    expect(cliResult.status).toBe(0);
+    expect(cliResult.stderr).toBe("");
+    expect(report.diagnostics).toHaveLength(0);
+    expect(report.validatedDeclarations).toBe(0);
+  });
+
+  it(
+    "warns when CLI token files are provided without enabling unknown custom property checks",
+    {
+      timeout: 120000,
+    },
+    () => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+      const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+      const validationPath = path.join(fixtureDir, "component.css");
+      const tokenPath = path.join(fixtureDir, "tokens.css");
+
+      writeFileSync(validationPath, ".card { color: var(--missing-color); }\n");
+      writeFileSync(tokenPath, ":root { --surface-color: canvas; }\n");
+
+      const cliResult = spawnSync(
+        "node",
+        ["packages/cli/dist/cli.js", validationPath, "--tokens", tokenPath],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+        },
+      );
+
+      expect(cliResult.status).toBe(0);
+      expect(cliResult.stderr).toContain(
+        "Warning: --tokens is ignored unless --check-unknown-custom-properties is enabled.",
+      );
+      expect(cliResult.stdout.trim()).toBe("No validation issues found.");
     },
   );
 

--- a/packages/vscode/CHANGELOG.md
+++ b/packages/vscode/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.2.1
+
+- Make unresolved no-fallback custom property diagnostics opt-in.
+- Add `checkUnknownCustomProperties` and `tokenFiles` workspace settings.
+
 ## 0.1.1
 
 - Include bundled mdn-data JSON files required by the packaged extension runtime.

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -5,7 +5,8 @@ Validate typed CSS custom property registrations and `var()` usage directly in V
 ## Features
 
 - Validates plain CSS documents as you edit.
-- Reports native editor diagnostics for invalid `@property` registrations, incompatible registered custom property assignments, incompatible `var()` usage, unknown no-fallback `var()` references, unresolved imports, and parse failures.
+- Reports native editor diagnostics for invalid `@property` registrations, incompatible registered custom property assignments, incompatible `var()` usage, unresolved imports, and parse failures.
+- Optionally reports unknown no-fallback `var()` references from configured token files.
 - Supports shared `@property` registry files through workspace settings.
 - Refreshes registry inputs and open-document diagnostics with one command.
 
@@ -21,16 +22,29 @@ Shared registry files are configured with workspace-relative glob patterns:
 
 Registry files contribute `@property` registrations and registration diagnostics. Ordinary declarations from registry files are not validated unless the file is also open as a CSS document.
 
+Unknown custom property checks are off by default. Enable them with token files that represent the project custom property source of truth:
+
+```json
+{
+  "cssPropertyTypeValidator.checkUnknownCustomProperties": true,
+  "cssPropertyTypeValidator.tokenFiles": ["src/tokens/**/*.css"]
+}
+```
+
+Token files seed known custom property names without validating ordinary declarations from those files.
+
+The extension warns when unknown custom property checks are enabled without `tokenFiles`, and when `tokenFiles` are configured while the check is disabled.
+
 ## Commands
 
-- `CSS Property Type Validator: Refresh` reloads configured registry files and revalidates open CSS documents.
+- `CSS Property Type Validator: Refresh` reloads configured registry and token files, then revalidates open CSS documents.
 
 ## Known Limits
 
 - V1 validates CSS files only.
 - Desktop VS Code-compatible editors are supported; web extension hosts such as vscode.dev and GitHub.dev are out of scope for this version.
 - Embedded HTML style blocks, SCSS, Less, PostCSS, Vue, Svelte, JSX, and TSX are out of scope for this version.
-- Unresolved `var()` diagnostics are static known-inputs checks, not full browser cascade evaluations for a specific DOM element.
+- Unresolved `var()` diagnostics are opt-in static known-inputs checks, not full browser cascade evaluations for a specific DOM element.
 - The extension does not provide autofixes.
 
 ## Packaging And Release

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "css-property-type-validator",
   "displayName": "CSS Property Type Validator",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Validate typed CSS custom property registrations and var() usage in CSS files.",
   "categories": [
     "Linters",
@@ -65,6 +65,19 @@
             "type": "string"
           },
           "description": "Workspace-relative CSS file glob patterns to use as shared @property registry inputs."
+        },
+        "cssPropertyTypeValidator.checkUnknownCustomProperties": {
+          "type": "boolean",
+          "default": false,
+          "description": "Report var() references without fallbacks when the custom property is missing from known custom property inputs."
+        },
+        "cssPropertyTypeValidator.tokenFiles": {
+          "type": "array",
+          "default": [],
+          "items": {
+            "type": "string"
+          },
+          "description": "Workspace-relative CSS file glob patterns to use as known custom property token sources when unknown custom property checking is enabled."
         }
       }
     }

--- a/packages/vscode/src/extension.ts
+++ b/packages/vscode/src/extension.ts
@@ -19,6 +19,8 @@ const VALIDATION_DEBOUNCE_MS = 300;
 
 let diagnosticCollection: vscode.DiagnosticCollection;
 let registryInputs: ValidationInput[] = [];
+let knownCustomPropertyInputs: ValidationInput[] = [];
+let lastConfigurationWarningKey: string | null = null;
 const validationTimers = new Map<string, NodeJS.Timeout>();
 const diagnosticUris = new Set<string>();
 
@@ -30,10 +32,24 @@ function isCssFileDocument(document: vscode.TextDocument): boolean {
 }
 
 function getRegistryPatterns(): string[] {
+  return getConfigurationPatterns("registryFiles");
+}
+
+function getTokenPatterns(): string[] {
+  return getConfigurationPatterns("tokenFiles");
+}
+
+function getConfigurationPatterns(name: string): string[] {
   return vscode.workspace
     .getConfiguration("cssPropertyTypeValidator")
-    .get<string[]>("registryFiles", [])
+    .get<string[]>(name, [])
     .filter((pattern) => pattern.trim().length > 0);
+}
+
+function shouldCheckUnknownCustomProperties(): boolean {
+  return vscode.workspace
+    .getConfiguration("cssPropertyTypeValidator")
+    .get<boolean>("checkUnknownCustomProperties", false);
 }
 
 async function readWorkspaceFile(uri: vscode.Uri): Promise<string> {
@@ -41,9 +57,8 @@ async function readWorkspaceFile(uri: vscode.Uri): Promise<string> {
   return new TextDecoder().decode(bytes);
 }
 
-async function loadRegistryInputs(): Promise<ValidationInput[]> {
+async function loadConfiguredInputs(patterns: string[]): Promise<ValidationInput[]> {
   const workspaceFolders = vscode.workspace.workspaceFolders ?? [];
-  const patterns = getRegistryPatterns();
   const inputsByPath = new Map<string, ValidationInput>();
 
   for (const folder of workspaceFolders) {
@@ -65,6 +80,39 @@ async function loadRegistryInputs(): Promise<ValidationInput[]> {
   }
 
   return [...inputsByPath.values()].sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function loadRegistryInputs(): Promise<ValidationInput[]> {
+  return loadConfiguredInputs(getRegistryPatterns());
+}
+
+async function loadKnownCustomPropertyInputs(): Promise<ValidationInput[]> {
+  return shouldCheckUnknownCustomProperties() ? loadConfiguredInputs(getTokenPatterns()) : [];
+}
+
+function showUnknownCustomPropertyConfigurationWarning(): void {
+  const shouldCheck = shouldCheckUnknownCustomProperties();
+  const tokenPatterns = getTokenPatterns();
+  let nextWarningKey: string | null = null;
+  let message: string | null = null;
+
+  if (shouldCheck && tokenPatterns.length === 0) {
+    nextWarningKey = "enabled-without-token-files";
+    message =
+      "CSS Property Type Validator: unknown custom property checks are enabled without tokenFiles. Configure tokenFiles to avoid false positives from project-wide custom properties outside the validation/import path.";
+  } else if (!shouldCheck && tokenPatterns.length > 0) {
+    nextWarningKey = "token-files-disabled";
+    message =
+      "CSS Property Type Validator: tokenFiles are ignored unless checkUnknownCustomProperties is enabled.";
+  }
+
+  if (!message || nextWarningKey === lastConfigurationWarningKey) {
+    lastConfigurationWarningKey = nextWarningKey;
+    return;
+  }
+
+  lastConfigurationWarningKey = nextWarningKey;
+  void vscode.window.showWarningMessage(message);
 }
 
 function getWorkspaceFolderForPath(filePath: string): vscode.WorkspaceFolder | undefined {
@@ -160,6 +208,8 @@ function getOpenCssInputs(): ValidationInput[] {
 function validateOpenCssDocuments(): void {
   const inputs = getOpenCssInputs();
   const result = validateFiles(inputs, {
+    checkUnresolvedCustomProperties: shouldCheckUnknownCustomProperties(),
+    knownCustomPropertyInputs,
     registryInputs,
     resolveImport: createImportResolver(),
   });
@@ -189,7 +239,9 @@ function scheduleValidation(document: vscode.TextDocument, delay = VALIDATION_DE
 }
 
 async function reloadRegistryAndValidate(): Promise<void> {
+  showUnknownCustomPropertyConfigurationWarning();
   registryInputs = await loadRegistryInputs();
+  knownCustomPropertyInputs = await loadKnownCustomPropertyInputs();
   validateOpenCssDocuments();
 }
 
@@ -208,7 +260,11 @@ function handleClosedDocument(document: vscode.TextDocument): void {
 }
 
 async function handleConfigurationChanged(event: vscode.ConfigurationChangeEvent): Promise<void> {
-  if (event.affectsConfiguration("cssPropertyTypeValidator.registryFiles")) {
+  if (
+    event.affectsConfiguration("cssPropertyTypeValidator.registryFiles") ||
+    event.affectsConfiguration("cssPropertyTypeValidator.tokenFiles") ||
+    event.affectsConfiguration("cssPropertyTypeValidator.checkUnknownCustomProperties")
+  ) {
     await reloadRegistryAndValidate();
   }
 }

--- a/packages/vscode/test/suite/extension.test.cts
+++ b/packages/vscode/test/suite/extension.test.cts
@@ -49,6 +49,12 @@ suite("CSS Property Type Validator extension", () => {
     await vscode.workspace
       .getConfiguration("cssPropertyTypeValidator")
       .update("registryFiles", undefined, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace
+      .getConfiguration("cssPropertyTypeValidator")
+      .update("tokenFiles", undefined, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace
+      .getConfiguration("cssPropertyTypeValidator")
+      .update("checkUnknownCustomProperties", undefined, vscode.ConfigurationTarget.Workspace);
   });
 
   test("reports and clears diagnostics for an open CSS document", async () => {
@@ -81,9 +87,25 @@ suite("CSS Property Type Validator extension", () => {
     await waitForDiagnostics(document.uri, 0);
   });
 
-  test("reports unresolved var references for open CSS documents", async () => {
+  test("does not report unresolved var references by default", async () => {
     const componentUri = await writeWorkspaceFile(
       "unresolved-var-component.css",
+      ".card { color: var(--missing-color); }",
+    );
+    const document = await vscode.workspace.openTextDocument(componentUri);
+
+    await vscode.window.showTextDocument(document);
+    await vscode.commands.executeCommand("cssPropertyTypeValidator.refresh");
+
+    await waitForDiagnostics(document.uri, 0);
+  });
+
+  test("reports unresolved var references when enabled", async () => {
+    await vscode.workspace
+      .getConfiguration("cssPropertyTypeValidator")
+      .update("checkUnknownCustomProperties", true, vscode.ConfigurationTarget.Workspace);
+    const componentUri = await writeWorkspaceFile(
+      "enabled-unresolved-var-component.css",
       ".card { color: var(--missing-color); }",
     );
     const document = await vscode.workspace.openTextDocument(componentUri);
@@ -94,6 +116,27 @@ suite("CSS Property Type Validator extension", () => {
     assert.equal(diagnostics[0]?.source, "CSS Property Type Validator");
     assert.equal(diagnostics[0]?.code, "unresolved-var-reference");
     assert.match(diagnostics[0]?.message ?? "", /not a full browser cascade evaluation/);
+  });
+
+  test("uses configured token files for unresolved var references", async () => {
+    await writeWorkspaceFile("known-tokens.css", ":root { --surface-color: canvas; }");
+    const componentUri = await writeWorkspaceFile(
+      "token-backed-component.css",
+      ".card { color: var(--surface-color); }",
+    );
+
+    await vscode.workspace
+      .getConfiguration("cssPropertyTypeValidator")
+      .update("checkUnknownCustomProperties", true, vscode.ConfigurationTarget.Workspace);
+    await vscode.workspace
+      .getConfiguration("cssPropertyTypeValidator")
+      .update("tokenFiles", ["known-tokens.css"], vscode.ConfigurationTarget.Workspace);
+
+    const document = await vscode.workspace.openTextDocument(componentUri);
+    await vscode.window.showTextDocument(document);
+    await vscode.commands.executeCommand("cssPropertyTypeValidator.refresh");
+
+    await waitForDiagnostics(componentUri, 0);
   });
 
   test("reports diagnostics when only a registry file is configured", async () => {

--- a/web/index.html
+++ b/web/index.html
@@ -56,6 +56,26 @@
         </div>
         <section class="header-actions" aria-labelledby="header-actions-title">
           <h2 class="visually-hidden" id="header-actions-title">Validation actions</h2>
+          <label class="check-toggle" for="unknown-custom-properties-input">
+            <input
+              id="unknown-custom-properties-input"
+              class="js-check-unknown-custom-properties"
+              type="checkbox"
+            />
+            <span>Unknown custom properties</span>
+          </label>
+          <label class="file-button" for="token-file-input">
+            <span>Open Tokens</span>
+            <input
+              id="token-file-input"
+              class="js-token-file-input"
+              type="file"
+              accept=".css,text/css"
+              multiple
+              disabled
+              title="Select one or more CSS token files. Folder upload is not supported."
+            />
+          </label>
           <label class="file-button" for="css-file-input">
             <span>Open CSS</span>
             <input id="css-file-input" class="js-file-input" type="file" accept=".css,text/css" />

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schalkneethling/css-property-type-validator-web",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "private": true,
   "description": "Browser UI for CSS Property Type Validator.",
   "type": "module",

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -2,6 +2,7 @@ import {
   formatValidationResult,
   validateFiles,
   type OutputFormat,
+  type ValidationInput,
   type ValidationResult,
 } from "@schalkneethling/css-property-type-validator-core";
 
@@ -42,13 +43,20 @@ function requireCachedValue<T>(value: T | null, name: string): T {
   return value;
 }
 
+function tokenInputPath(file: File, index: number): string {
+  return file.webkitRelativePath || file.name || `tokens-${index + 1}.css`;
+}
+
 class ValidatorController extends HTMLElement {
   #cssSource = DEFAULT_CSS;
   #fileName = "pasted.css";
+  #checkUnknownCustomProperties = false;
   #outputFormat: OutputFormat = "human";
   #result: ValidationResult | null = null;
+  #tokenInputs: ValidationInput[] = [];
 
   #abortController: AbortController | null = null;
+  #checkUnknownCustomPropertiesInput: HTMLInputElement | null = null;
   #fileInput: HTMLInputElement | null = null;
   #fileNameElement: HTMLElement | null = null;
   #inputEditor: CodeEditorElement | null = null;
@@ -58,6 +66,7 @@ class ValidatorController extends HTMLElement {
   #statRegistered: HTMLElement | null = null;
   #statSkipped: HTMLElement | null = null;
   #statValidated: HTMLElement | null = null;
+  #tokenFileInput: HTMLInputElement | null = null;
   #validationStatus: HTMLElement | null = null;
   #validateButton: HTMLButtonElement | null = null;
 
@@ -74,6 +83,10 @@ class ValidatorController extends HTMLElement {
   }
 
   #cacheDOMElements(): void {
+    this.#checkUnknownCustomPropertiesInput = queryElement<HTMLInputElement>(
+      this,
+      ".js-check-unknown-custom-properties",
+    );
     this.#fileInput = queryElement<HTMLInputElement>(this, ".js-file-input");
     this.#fileNameElement = queryElement<HTMLElement>(this, ".js-file-name");
     this.#inputEditor = queryElement<CodeEditorElement>(this, ".js-input-editor");
@@ -85,6 +98,7 @@ class ValidatorController extends HTMLElement {
     this.#statRegistered = queryElement<HTMLElement>(this, ".js-stat-registered");
     this.#statSkipped = queryElement<HTMLElement>(this, ".js-stat-skipped");
     this.#statValidated = queryElement<HTMLElement>(this, ".js-stat-validated");
+    this.#tokenFileInput = queryElement<HTMLInputElement>(this, ".js-token-file-input");
     this.#validationStatus = queryElement<HTMLElement>(this, ".js-validation-status");
     this.#validateButton = queryElement<HTMLButtonElement>(this, ".js-validate-button");
   }
@@ -97,17 +111,29 @@ class ValidatorController extends HTMLElement {
     inputEditor.value = this.#cssSource;
     outputEditor.value = INITIAL_OUTPUT;
     fileNameElement.textContent = this.#fileName;
+    requireCachedValue(this.#tokenFileInput, "token file input").disabled = true;
   }
 
   #addEventListeners(): void {
     const abortController = requireCachedValue(this.#abortController, "abort controller");
+    const checkUnknownCustomPropertiesInput = requireCachedValue(
+      this.#checkUnknownCustomPropertiesInput,
+      "unknown custom properties input",
+    );
     const fileInput = requireCachedValue(this.#fileInput, "file input");
     const inputEditor = requireCachedValue(this.#inputEditor, "input editor");
+    const tokenFileInput = requireCachedValue(this.#tokenFileInput, "token file input");
     const validateButton = requireCachedValue(this.#validateButton, "validate button");
     const { signal } = abortController;
 
+    checkUnknownCustomPropertiesInput.addEventListener(
+      "change",
+      this.#handleUnknownCustomPropertiesChange,
+      { signal },
+    );
     fileInput.addEventListener("change", this.#handleFileSelection, { signal });
     inputEditor.addEventListener("editor-change", this.#handleEditorChange, { signal });
+    tokenFileInput.addEventListener("change", this.#handleTokenFileSelection, { signal });
     validateButton.addEventListener("click", this.#validateCss, { signal });
 
     for (const input of this.#outputFormatInputs) {
@@ -117,6 +143,12 @@ class ValidatorController extends HTMLElement {
 
   #handleEditorChange = (event: Event): void => {
     this.#cssSource = (event as CustomEvent<string>).detail;
+  };
+
+  #handleUnknownCustomPropertiesChange = (event: Event): void => {
+    this.#checkUnknownCustomProperties = (event.currentTarget as HTMLInputElement).checked;
+    requireCachedValue(this.#tokenFileInput, "token file input").disabled =
+      !this.#checkUnknownCustomProperties;
   };
 
   #handleFileSelection = async (event: Event): Promise<void> => {
@@ -134,6 +166,19 @@ class ValidatorController extends HTMLElement {
     input.value = "";
   };
 
+  #handleTokenFileSelection = async (event: Event): Promise<void> => {
+    const input = event.currentTarget as HTMLInputElement;
+    const files = Array.from(input.files ?? []);
+
+    this.#tokenInputs = await Promise.all(
+      files.map(async (file, index) => ({
+        path: tokenInputPath(file, index),
+        css: await file.text(),
+      })),
+    );
+    input.value = "";
+  };
+
   #handleFormatChange = (event: Event): void => {
     const input = event.currentTarget as HTMLInputElement;
 
@@ -142,12 +187,18 @@ class ValidatorController extends HTMLElement {
   };
 
   #validateCss = (): void => {
-    this.#result = validateFiles([
+    this.#result = validateFiles(
+      [
+        {
+          path: this.#fileName || "pasted.css",
+          css: this.#cssSource,
+        },
+      ],
       {
-        path: this.#fileName || "pasted.css",
-        css: this.#cssSource,
+        checkUnresolvedCustomProperties: this.#checkUnknownCustomProperties,
+        knownCustomPropertyInputs: this.#checkUnknownCustomProperties ? this.#tokenInputs : [],
       },
-    ]);
+    );
     this.#renderOutput();
     this.#renderStatus();
     this.#renderStats();
@@ -177,9 +228,23 @@ class ValidatorController extends HTMLElement {
   #renderStatus(): void {
     const validationStatus = requireCachedValue(this.#validationStatus, "validation status");
     const hasPassed = Boolean(this.#result && this.#result.diagnostics.length === 0);
+    const configurationWarning = this.#configurationWarning();
 
     validationStatus.replaceChildren();
-    validationStatus.hidden = !hasPassed;
+    validationStatus.hidden = !configurationWarning && !hasPassed;
+
+    if (configurationWarning) {
+      const warning = document.createElement("div");
+      const heading = document.createElement("strong");
+      const detail = document.createElement("span");
+
+      warning.className = "warning-message";
+      warning.role = "status";
+      heading.textContent = "Configuration warning.";
+      detail.textContent = configurationWarning;
+      warning.append(heading, detail);
+      validationStatus.append(warning);
+    }
 
     if (!hasPassed) {
       return;
@@ -196,6 +261,18 @@ class ValidatorController extends HTMLElement {
 
     message.append(heading, detail);
     validationStatus.append(message);
+  }
+
+  #configurationWarning(): string | null {
+    if (this.#checkUnknownCustomProperties && this.#tokenInputs.length === 0) {
+      return "Choose token files to reduce false positives from project-wide custom properties outside the pasted CSS.";
+    }
+
+    if (!this.#checkUnknownCustomProperties && this.#tokenInputs.length > 0) {
+      return "Token files are ignored while unknown custom property checks are off.";
+    }
+
+    return null;
   }
 }
 

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -584,6 +584,7 @@ h2 {
   gap: 0.6rem;
 }
 
+.check-toggle,
 .file-button,
 .primary-action {
   display: inline-grid;
@@ -595,6 +596,19 @@ h2 {
   padding-inline: 1rem;
   font: var(--font-control);
   letter-spacing: 0.01em;
+}
+
+.check-toggle {
+  grid-auto-flow: column;
+  gap: 0.5rem;
+  color: var(--color-panel);
+  background: transparent;
+}
+
+.check-toggle input {
+  accent-color: var(--color-accent);
+  inline-size: 1rem;
+  block-size: 1rem;
 }
 
 .file-button {
@@ -618,11 +632,13 @@ h2 {
 }
 
 .file-button:hover,
+.check-toggle:hover,
 .primary-action:hover {
   translate: 0 -0.0625rem;
 }
 
 .file-button:focus-within,
+.check-toggle:focus-within,
 .primary-action:focus-visible,
 .format-toggle input:focus-visible + span {
   outline: 0.1875rem solid var(--color-focus);
@@ -768,7 +784,8 @@ h2 {
   background: var(--color-editor-output);
 }
 
-.success-message {
+.success-message,
+.warning-message {
   display: flex;
   align-items: center;
   justify-content: space-between;
@@ -781,11 +798,18 @@ h2 {
   border-block-end: 0.0625rem solid var(--color-success-border);
 }
 
-.success-message strong {
+.warning-message {
+  color: var(--color-heading);
+  background: var(--color-page);
+}
+
+.success-message strong,
+.warning-message strong {
   font: var(--font-success);
 }
 
-.success-message span {
+.success-message span,
+.warning-message span {
   color: var(--color-success-muted);
   font: var(--font-success-detail);
 }
@@ -874,7 +898,8 @@ h2 {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
-  .success-message {
+  .success-message,
+  .warning-message {
     align-items: flex-start;
     flex-direction: column;
     gap: 0.2rem;

--- a/web/tests/e2e/validator.e2e.ts
+++ b/web/tests/e2e/validator.e2e.ts
@@ -52,6 +52,9 @@ test("renders the validator workspace", async ({ page }) => {
           - /url: https://github.com/schalkneethling/css-property-type-validator
       - region "Validation actions":
         - heading "Validation actions" [level=2]
+        - checkbox "Unknown custom properties"
+        - text: Unknown custom properties Open Tokens
+        - button "Open Tokens" [disabled]
         - text: Open CSS
         - button "Open CSS"
         - button "Validate"
@@ -109,13 +112,47 @@ test("switches diagnostics to pretty JSON", async ({ page }) => {
   await expect(page.getByText('"code": "incompatible-var-usage"')).toBeVisible();
 });
 
-test("shows unresolved var diagnostics in the browser output", async ({ page }) => {
+test("does not show unresolved var diagnostics by default", async ({ page }) => {
   await page.goto("/");
   await replaceEditorContents(page, UNRESOLVED_CSS);
   await page.getByRole("button", { name: "Validate" }).click();
 
+  await expect(page.getByRole("status")).toContainText("No validation issues found.");
+  await expect(page.getByText("Custom property --missing-color is not defined")).toBeHidden();
+});
+
+test("shows unresolved var diagnostics when enabled", async ({ page }) => {
+  await page.goto("/");
+  await replaceEditorContents(page, UNRESOLVED_CSS);
+  await page.getByLabel("Unknown custom properties").check();
+  await page.getByRole("button", { name: "Validate" }).click();
+
   await expect(page.getByText("Custom property --missing-color is not defined")).toBeVisible();
   await expect(page.getByText("not a full browser cascade evaluation")).toBeVisible();
+});
+
+test("warns when unresolved var checks are enabled without token files", async ({ page }) => {
+  await page.goto("/");
+  await replaceEditorContents(page, `.card {\n  color: var(--missing-color, red);\n}`);
+  await page.getByLabel("Unknown custom properties").check();
+  await page.getByRole("button", { name: "Validate" }).click();
+
+  await expect(page.getByText("Configuration warning.")).toBeVisible();
+  await expect(page.getByText("Choose token files")).toBeVisible();
+});
+
+test("uses token files for unresolved var diagnostics when enabled", async ({ page }) => {
+  await page.goto("/");
+  await replaceEditorContents(page, `.card {\n  color: var(--surface-color);\n}`);
+  await page.getByLabel("Unknown custom properties").check();
+  await page.getByLabel("Open Tokens").setInputFiles({
+    name: "tokens.css",
+    mimeType: "text/css",
+    buffer: Buffer.from(":root { --surface-color: canvas; }\n"),
+  });
+  await page.getByRole("button", { name: "Validate" }).click();
+
+  await expect(page.getByRole("status")).toContainText("No validation issues found.");
 });
 
 test("shows the success state for valid CSS", async ({ page }) => {


### PR DESCRIPTION
## Summary
- Make unresolved `var()` diagnostics opt in across core, CLI, VS Code, and web.
- Add token-file inputs so projects can seed the known custom property set from dedicated CSS sources.
- Keep existing `@property` registry behavior intact and document the new pattern for consumers.

## Testing
- Added and updated core unit tests for opt-in unresolved checks, token inputs, nested imports, and cycle handling.
- Updated CLI, VS Code, and web integration coverage for the new settings, warnings, and token-file flows.
- Ran formatting, type checking, unit tests, Playwright e2e tests, and the full repo check locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional checking for unknown custom properties across CLI, VS Code extension, and web tool
  * Introduced `--check-unknown-custom-properties` and `--tokens` CLI flags
  * Added workspace configuration options to VS Code extension
  * Support for seeding known custom properties from token files

* **Documentation**
  * Updated CLI and product documentation with new configuration options
  * VS Code extension version updated to 0.2.1

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/schalkneethling/css-property-type-validator/pull/62)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->