### PR TITLE
Add explicit workflow for syncing generated VS Code data

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,3 +19,8 @@ updates:
     directory: "/packages/cli"
     schedule:
       interval: "weekly"
+
+  - package-ecosystem: "npm"
+    directory: "/packages/vscode"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.1.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.33.0
+          version: 11.1.2
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,9 @@ jobs:
       - name: Typecheck
         run: pnpm run typecheck
 
+      - name: Check generated VS Code data
+        run: pnpm run check:vscode-data
+
       - name: Run tests
         run: pnpm test
 

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -30,7 +30,7 @@ jobs:
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: pnpm/action-setup@v4
         with:
-          version: 10.33.0
+          version: 11.1.2
 
       - name: Set up Node.js
         if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -29,8 +29,6 @@ jobs:
       - name: Set up pnpm
         if: ${{ steps.release.outputs.releases_created == 'true' }}
         uses: pnpm/action-setup@v4
-        with:
-          version: 11.1.2
 
       - name: Set up Node.js
         if: ${{ steps.release.outputs.releases_created == 'true' }}

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "type": "module",
   "scripts": {
     "build": "pnpm -r --if-present run build",
+    "check:vscode-data": "pnpm --filter ./packages/vscode run check:data",
     "check": "vp check && pnpm run typecheck && pnpm test && pnpm run build",
     "format": "vp check --fix",
     "format:check": "vp check --no-lint",
@@ -24,6 +25,7 @@
     "test": "vp test run",
     "test:e2e": "pnpm --filter @schalkneethling/css-property-type-validator-web test:e2e",
     "typecheck": "tsc -b tsconfig.json",
+    "update:vscode-data": "pnpm --filter ./packages/vscode run sync:data && pnpm run format",
     "check:supported-syntax-names": "node scripts/check-supported-syntax-names.mjs",
     "clean": "node scripts/clean.mjs",
     "example": "pnpm run build && node packages/cli/dist/cli.js fixtures/imports/main.css"
@@ -37,5 +39,5 @@
   "engines": {
     "node": ">=22.0.0"
   },
-  "packageManager": "pnpm@10.33.0"
+  "packageManager": "pnpm@11.1.2"
 }

--- a/packages/vscode/README.md
+++ b/packages/vscode/README.md
@@ -49,6 +49,14 @@ The extension warns when unknown custom property checks are enabled without `tok
 
 ## Packaging And Release
 
+Refresh the checked-in MDN and css-tree snapshots after dependency updates:
+
+```bash
+pnpm run update:vscode-data
+```
+
+The repository CI runs `pnpm run check:vscode-data` and fails with an explicit regeneration hint when the checked-in snapshot drifts from the installed dependency data. Regenerate the snapshot locally and commit the result before merging dependency updates.
+
 Build and package a VSIX:
 
 ```bash

--- a/packages/vscode/package.json
+++ b/packages/vscode/package.json
@@ -29,13 +29,16 @@
   "type": "module",
   "main": "./dist/extension.cjs",
   "scripts": {
-    "build": "pnpm run check-types && vp pack src/extension.ts -f cjs -d dist --platform node --target node22 --sourcemap --deps.neverBundle vscode --deps.alwaysBundle @schalkneethling/css-property-type-validator-core --deps.alwaysBundle css-tree --deps.onlyBundle css-tree --deps.onlyBundle source-map-js && node scripts/copy-css-tree-data.mjs",
+    "build": "pnpm run check-types && pnpm run bundle && pnpm run check:data",
+    "bundle": "vp pack src/extension.ts -f cjs -d dist --platform node --target node22 --sourcemap --deps.neverBundle vscode --deps.alwaysBundle @schalkneethling/css-property-type-validator-core --deps.alwaysBundle css-tree --deps.onlyBundle css-tree --deps.onlyBundle source-map-js",
+    "check:data": "node scripts/copy-css-tree-data.mjs --check",
     "check-types": "tsc --noEmit -p tsconfig.json",
     "compile-tests": "tsc -p tsconfig.test.json",
     "package:vsix": "vsce package --no-dependencies",
     "test": "pnpm run build && pnpm run compile-tests && node ./out/test/run.js",
+    "sync:data": "node scripts/copy-css-tree-data.mjs --write",
     "vscode:prepublish": "pnpm run build",
-    "watch": "vp pack src/extension.ts -f cjs -d dist --platform node --target node22 --sourcemap --deps.neverBundle vscode --deps.alwaysBundle @schalkneethling/css-property-type-validator-core --deps.alwaysBundle css-tree --deps.onlyBundle css-tree --deps.onlyBundle source-map-js --watch src"
+    "watch": "pnpm run bundle -- --watch src"
   },
   "dependencies": {
     "@schalkneethling/css-property-type-validator-core": "workspace:*"

--- a/packages/vscode/scripts/copy-css-tree-data.mjs
+++ b/packages/vscode/scripts/copy-css-tree-data.mjs
@@ -1,4 +1,4 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, writeFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
@@ -29,23 +29,44 @@ const generatedPatchPath = join(generatedDataRoot, "patch.json");
 const bundledEntryPath = join(packageRoot, "dist/extension.cjs");
 
 const mdnDataFiles = ["at-rules.json", "properties.json", "syntaxes.json"];
+const mode = process.argv.includes("--write") ? "write" : "check";
 
-async function ensureGeneratedJson(sourcePath, targetPath, message) {
+function getUpdateHint(targetPath) {
+  return `${targetPath} differs from its source dependency. Run \`pnpm run update:vscode-data\` to regenerate and format the checked-in snapshot.`;
+}
+
+async function syncGeneratedJson(sourcePath, targetPath) {
   const sourceData = JSON.parse(await readFile(sourcePath, "utf8"));
   const sourceDataKey = JSON.stringify(sourceData);
 
   try {
     const existingData = JSON.parse(await readFile(targetPath, "utf8"));
 
-    if (JSON.stringify(existingData) !== sourceDataKey) {
-      throw new Error(message);
+    if (JSON.stringify(existingData) === sourceDataKey) {
+      return;
     }
+
+    if (mode === "write") {
+      await writeFile(targetPath, `${JSON.stringify(sourceData, null, 2)}\n`);
+      return;
+    }
+
+    throw new Error(getUpdateHint(targetPath));
   } catch (error) {
+    if (error instanceof Error && error.message === getUpdateHint(targetPath)) {
+      throw error;
+    }
+
     if (error?.code !== "ENOENT") {
       throw error;
     }
 
-    await writeFile(targetPath, `${JSON.stringify(sourceData, null, 2)}\n`);
+    if (mode === "write") {
+      await writeFile(targetPath, `${JSON.stringify(sourceData, null, 2)}\n`);
+      return;
+    }
+
+    throw new Error(getUpdateHint(targetPath));
   }
 }
 
@@ -53,18 +74,19 @@ await mkdir(join(generatedDataRoot, "mdn-data/css"), { recursive: true });
 
 // These JSON files are generated from core's css-tree/mdn-data dependencies and
 // formatted by the repo formatter. Keep them stable during normal builds.
-await ensureGeneratedJson(
-  join(cssTreeRoot, "data/patch.json"),
-  generatedPatchPath,
-  "packages/vscode/data/patch.json differs from core's css-tree data. Regenerate and format the file before building the extension.",
-);
+await syncGeneratedJson(join(cssTreeRoot, "data/patch.json"), generatedPatchPath);
 
 for (const fileName of mdnDataFiles) {
-  await ensureGeneratedJson(
+  await syncGeneratedJson(
     join(mdnDataRoot, "css", fileName),
     join(generatedDataRoot, "mdn-data/css", fileName),
-    `packages/vscode/data/mdn-data/css/${fileName} differs from core's mdn-data dependency. Regenerate and format the file before building the extension.`,
   );
+}
+
+try {
+  await access(bundledEntryPath);
+} catch {
+  process.exit(0);
 }
 
 let bundledEntry = await readFile(bundledEntryPath, "utf8");


### PR DESCRIPTION
## Summary
- Add first-class commands for regenerating and checking the VS Code MDN/csstree snapshot data.
- Make CI fail with a clear regeneration hint when the checked-in snapshot drifts from the installed dependency data.
- Document the manual sync step and expand Dependabot coverage to the VS Code package.

## Testing
- `pnpm run format:check` passed.
- `pnpm run lint` passed.
- `pnpm run typecheck` passed.
- `pnpm run check:vscode-data` passed.
- `pnpm test` passed.
- `pnpm run build` passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Upgraded package manager to pnpm@11.1.2
  * Enhanced automated dependency updates for the VS Code package via Dependabot

* **CI/CD**
  * Added new data integrity check step to the continuous integration pipeline

* **Documentation**
  * Updated maintainer guidelines for packaging and releasing VS Code extension with instructions for refreshing snapshots after dependency updates

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/schalkneethling/css-property-type-validator/pull/68?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->