### PR TITLE
Fix stylelint release ordering and add publish dependency canary

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -92,6 +92,27 @@ jobs:
       - name: Pack Stylelint package
         run: pnpm --filter @schalkneethling/stylelint-plugin-css-property-type-validator pack --pack-destination package
 
+      - name: Verify Stylelint package against published dependencies
+        if: startsWith(github.event.release.tag_name, 'stylelint-v')
+        run: |
+          tarball="$(find package -type f -name "schalkneethling-stylelint-plugin-css-property-type-validator-*.tgz" -print -quit)"
+
+          if [ -z "$tarball" ]; then
+            echo "No Stylelint package tarball found."
+            find package -maxdepth 2 -type f -print
+            exit 1
+          fi
+
+          temp_dir="$(mktemp -d)"
+          npm --prefix "$temp_dir" install --ignore-scripts --no-audit --no-fund "$tarball" stylelint
+          cd "$temp_dir"
+          node --input-type=module --eval "
+            const plugin = await import('@schalkneethling/stylelint-plugin-css-property-type-validator');
+            if (plugin.ruleName !== 'css-property-type-validator/valid-property-types') {
+              throw new Error('Stylelint plugin did not expose the expected ruleName.');
+            }
+          "
+
       - name: Upload package tarballs
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,9 +51,11 @@ Publish by creating and publishing a GitHub Release whose tag identifies the pac
 
 Use `stylelint-v0.1.0-beta.0` for the first Stylelint beta release.
 
+Packages that depend on workspace packages must only be released after their workspace dependencies have already been published at the versions that will be written into the packed package. For example, if the Stylelint plugin uses a new core export, bump and publish core first, or use an `all-vX.Y.Z` release so core is published before the plugin.
+
 ## Manual Release Steps
 
-1. Update the target package version in its `package.json`.
+1. Update the target package version in its `package.json`. If the target package depends on another workspace package whose public API changed, update that dependency package version too.
 2. Update the relevant changelog or release notes.
 3. Run the local verification gate:
 
@@ -74,7 +76,7 @@ Use `stylelint-v0.1.0-beta.0` for the first Stylelint beta release.
    ```
 
 5. Merge the release-prep PR.
-6. Create and publish a GitHub Release with the matching tag prefix.
+6. Create and publish a GitHub Release with the matching tag prefix. Use `all-vX.Y.Z` when releasing a package together with a workspace dependency it relies on.
 7. Confirm the `Publish` workflow completes and the package appears on npm.
 
 ## Security Notes

--- a/packages/core/CHANGELOG.md
+++ b/packages/core/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.11.2](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.11.1...core-v0.11.2) (2026-05-26)
+
+### Bug Fixes
+
+- publish the import URL helper used by downstream packages.
+
 ## [0.11.1](https://github.com/schalkneethling/css-property-type-validator/compare/core-v0.11.0...core-v0.11.1) (2026-05-10)
 
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schalkneethling/css-property-type-validator-core",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "description": "Standalone CSS custom property type validator core.",
   "keywords": [
     "css",

--- a/packages/stylelint/package.json
+++ b/packages/stylelint/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@schalkneethling/stylelint-plugin-css-property-type-validator",
-  "version": "0.1.0-beta.0",
+  "version": "0.1.0-beta.1",
   "description": "Stylelint plugin for CSS Property Type Validator.",
   "keywords": [
     "css",


### PR DESCRIPTION
## Summary
- Bump `core` to `0.11.2` and the Stylelint plugin to `0.1.0-beta.1` so the plugin can depend on the published core export surface it uses.
- Add a publish-workflow canary that installs the packed Stylelint tarball against published dependencies and imports the plugin before release.
- Document the release ordering rule for workspace-dependent packages in `RELEASING.md`.

## Testing
- `vp test run packages/stylelint/test/valid-property-types.test.ts` passed.
- Verified the Stylelint plugin rule still resolves from the built package.
- Not run (not requested): full publish workflow and registry-level release dry run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Core package now properly exports an import URL helper for downstream packages.

* **Chores**
  * Core package version updated to 0.11.2.
  * Stylelint plugin version updated to 0.1.0-beta.1.

* **Documentation**
  * Clarified release ordering constraints for workspace-dependent packages in release documentation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/schalkneethling/css-property-type-validator/pull/94?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->