### PR TITLE
Publish Stylelint prereleases with the beta dist-tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -147,6 +147,7 @@ jobs:
 
           publish_matching() {
             pattern="$1"
+            dist_tag="${2:-}"
             tarball="$(find package -type f -name "$pattern" -print -quit)"
 
             if [ -z "$tarball" ]; then
@@ -155,7 +156,13 @@ jobs:
               exit 1
             fi
 
-            npm publish "$(realpath "$tarball")" --ignore-scripts --access public
+            publish_args=(publish "$(realpath "$tarball")" --ignore-scripts --access public)
+
+            if [ -n "$dist_tag" ]; then
+              publish_args+=(--tag "$dist_tag")
+            fi
+
+            npm "${publish_args[@]}"
           }
 
           case "$tag" in
@@ -166,12 +173,12 @@ jobs:
               publish_matching "schalkneethling-css-property-type-validator-cli-*.tgz"
               ;;
             stylelint-v*)
-              publish_matching "schalkneethling-stylelint-plugin-css-property-type-validator-*.tgz"
+              publish_matching "schalkneethling-stylelint-plugin-css-property-type-validator-*.tgz" beta
               ;;
             all-v*)
               publish_matching "schalkneethling-css-property-type-validator-core-*.tgz"
               publish_matching "schalkneethling-css-property-type-validator-cli-*.tgz"
-              publish_matching "schalkneethling-stylelint-plugin-css-property-type-validator-*.tgz"
+              publish_matching "schalkneethling-stylelint-plugin-css-property-type-validator-*.tgz" beta
               ;;
             *)
               echo "Release tag must start with core-v, cli-v, stylelint-v, or all-v."


### PR DESCRIPTION
## Summary
- Update the publish workflow to pass an optional npm dist-tag when publishing tarballs.
- Publish `stylelint-v*` releases with the `beta` tag so prerelease versions do not fail npm’s prerelease guard.
- Apply the same `beta` tag when publishing Stylelint from `all-v*` releases.

## Testing
- Not run (not requested)
- Verified the workflow logic change in the release script path by inspection.