### PR TITLE
Add experimental CSS property generation workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 css-property-type-validator "src/tokens/**/*.css" --registry-only
 css-property-type-validator "src/**/*.css" --check-unknown-custom-properties --tokens "src/tokens/**/*.css"
 css-property-type-validator "src/**/*.css" --failfast
+css-property-type-validator generate "src/**/*.css" --out properties.css
 ```
 
 Use `--registry` for shared `@property` definitions that should contribute registrations without validating ordinary declarations from those files:
@@ -80,6 +81,27 @@ By default, the CLI collects every validation failure it can find and reports th
 Use `--failfast` when you want it to stop after the first validation failure, including
 registration/import failures and declaration usage failures. Human and JSON output keep the same
 format; the diagnostics array simply contains the first issue found.
+
+## Generate `@property` Rules
+
+Use the experimental `generate` command to create a reviewable `properties.css` file from existing custom property declarations:
+
+```bash
+css-property-type-validator generate "src/**/*.css" --out properties.css
+```
+
+Generation needs to see concrete authored custom property declarations such as:
+
+```css
+:root {
+  --brand-color: red;
+  --space: 1px;
+}
+```
+
+`var()` usage sites are optional. They can help you test the generated registrations with validation later, but the generator can infer registrations from token-only files.
+
+Alias tokens such as `--border-color: var(--brand-color)` can generate only when the referenced token declarations are also included in the inputs. If the generator only sees aliases and not the concrete primitive values they point to, those aliases are returned as review items.
 
 ## Stylelint Usage
 

--- a/draft.md
+++ b/draft.md
@@ -1,0 +1,170 @@
+# Lowering the Barrier to CSS `@property` Adoption
+
+CSS `@property` is one of those features that feels obviously useful once you spend time with it.
+
+It lets you register a custom property with a type, inheritance behavior, and initial value:
+
+```css
+@property --space {
+  syntax: "<length>";
+  inherits: false;
+  initial-value: 0px;
+}
+```
+
+That gives the browser, and developer tooling, more information about what your custom properties are meant to be. A spacing token can be treated as a length. A brand token can be treated as a color. Invalid values can be rejected earlier. Animations and transitions can behave more predictably. Tools can start reasoning about whether a `var()` usage makes sense in the place where it is used.
+
+And yet, `@property` still does not feel like a default part of how most people write CSS.
+
+I do not think that is because developers do not care. I think it is because adoption has a timing problem.
+
+## The Adoption Problem
+
+Most projects that would benefit from `@property` already have custom properties.
+
+They have token files. They have component-level variables. They have themes. They have years of CSS written before typed custom properties were part of the conversation.
+
+So when do you commit to adding `@property` registrations to an existing project?
+
+How do you justify the time?
+
+How do you decide which custom properties are worth registering first?
+
+How do you avoid turning a useful platform feature into a migration project nobody has time for?
+
+That is a familiar problem. The JavaScript ecosystem has lived with a version of it for years. Teams may like TypeScript, or even types via JSDoc, but adopting types in an existing codebase still has a cost. The question is rarely just "is this useful?" It is also "how do we start without stopping everything else?"
+
+CSS has its own version of this now.
+
+Many of us are not used to thinking about types in CSS. Even when starting a new project, it is easy to define custom properties as plain values and move on. Most CSS libraries and utility systems also do not ship with `@property` registrations today, so there is not yet a strong ecosystem norm to copy.
+
+That makes the blank page problem even harder.
+
+## A Different First Step
+
+I have been experimenting with a feature in [CSS Property Type Validator](https://github.com/schalkneethling/css-property-type-validator) that tries to make the first step smaller:
+
+Generate a draft `properties.css` file from the custom properties already present in a codebase.
+
+For example, given CSS like this:
+
+```css
+:root {
+  --brand-color: red;
+  --space: 1px;
+}
+```
+
+the tool can infer conservative `@property` registrations and write them to a separate file:
+
+```css
+@property --brand-color {
+  syntax: "<color>";
+  inherits: true;
+  initial-value: red;
+}
+
+@property --space {
+  syntax: "<length>";
+  inherits: true;
+  initial-value: 1px;
+}
+```
+
+The generated file is not meant to be magic. It is meant to be reviewable.
+
+You can keep it as-is and link it into the rest of your CSS. You can clean it up first. You can inspect the output and decide the project is not ready yet. All of those are useful outcomes because the time investment is much lower than starting from nothing.
+
+The important part is that adoption becomes exploratory instead of all-or-nothing.
+
+## Why This Belongs in the Validator
+
+CSS Property Type Validator started as a way to validate `@property` registrations and check whether registered custom properties are used compatibly through `var()`.
+
+For example, if `--brand-color` is registered as a color, the validator can catch it being used in a place that expects a length, such as `inline-size`.
+
+Generation feels like the other half of that workflow.
+
+Validation helps once you have typed custom properties. Generation helps you get there.
+
+That is why I do not currently think this should be a separate library. The adoption story is stronger when both pieces live together:
+
+1. Generate a conservative first draft from existing CSS.
+2. Review the generated `properties.css`.
+3. Link it into the project.
+4. Use validation to catch incompatible usage over time.
+
+The tool should not ask you to become a fully typed CSS project in one step. It should help you move in that direction gradually.
+
+## Why This Matters More Now
+
+Typed custom properties are already useful today, but I think they are going to become even more important as CSS gains more powerful authoring features.
+
+CSS custom functions and mixins are on the horizon. As CSS becomes more expressive, the values flowing through custom properties, functions, and reusable patterns become more important to understand.
+
+Types are not just about catching mistakes. They are about making intent visible.
+
+If a custom property is part of a design system API, knowing whether it is a color, length, percentage, number, image, or something else is valuable information. It helps browsers. It helps tools. It helps future maintainers. It helps the person trying to use the token correctly six months from now.
+
+But for that to become normal CSS practice, we need adoption paths that meet existing projects where they are.
+
+## Trying the Experiment
+
+The experimental generator is available through the CLI:
+
+```bash
+npx @schalkneethling/css-property-type-validator-cli generate "src/**/*.css"
+```
+
+By default, it writes to:
+
+```text
+properties.css
+```
+
+You can choose a different output file:
+
+```bash
+css-property-type-validator generate "src/**/*.css" --out src/tokens/properties.css
+```
+
+You can also inspect the generated and review-needed candidates as JSON:
+
+```bash
+css-property-type-validator generate "src/**/*.css" --format json
+```
+
+The generator is intentionally conservative. It needs concrete authored custom property declarations, such as:
+
+```css
+:root {
+  --brand-color: red;
+  --space: 1px;
+}
+```
+
+Alias tokens, such as `--border-color: var(--brand-color)`, can only be generated safely when the referenced token declarations are included in the input. If the tool cannot infer a registration with enough confidence, it should ask for review rather than inventing certainty.
+
+There is also a browser UI where you can paste or open CSS, switch to Generate mode, and preview the resulting `properties.css` in a second pane. That may be the easiest way to try the idea without committing to anything in a project.
+
+## What I Need Feedback On
+
+This is experimental, and I would love feedback from people trying it on real CSS.
+
+I am especially interested in:
+
+- Did the generated `@property` syntax match what you expected?
+- Which custom properties could not be inferred?
+- Did the output feel safe and useful to review?
+- Would this lower the barrier to adopting `@property` in an existing project?
+- What token patterns, theme structures, or CSS library conventions does the tool miss?
+- Would comments explaining why a type was inferred make the output more useful?
+- Should this stay as part of the main CLI and Web UI, or would a different workflow fit better?
+
+Please share feedback on GitHub:
+
+[github.com/schalkneethling/css-property-type-validator/issues/98](https://github.com/schalkneethling/css-property-type-validator/issues/98)
+
+Even if the answer is "this is not useful for my codebase yet," that is helpful to know.
+
+My hope is that this becomes a practical on-ramp to typed custom properties: not a perfect automatic migration, but a way to make the first move easier.

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -25,6 +25,7 @@ css-property-type-validator "src/**/*.css" --registry "src/tokens/**/*.css"
 css-property-type-validator "src/tokens/**/*.css" --registry-only
 css-property-type-validator "src/**/*.css" --check-unknown-custom-properties --tokens "src/tokens/**/*.css"
 css-property-type-validator "src/**/*.css" --failfast
+css-property-type-validator generate "src/**/*.css" --out properties.css
 ```
 
 Use `--registry` multiple times to include shared registration sources:
@@ -42,6 +43,27 @@ Unresolved `var()` diagnostics are static known-inputs checks enabled with `--ch
 The CLI prints a warning when unresolved checks are enabled without `--tokens`, and when `--tokens` is provided without enabling unresolved checks.
 
 By default, the CLI collects and reports all validation failures. Use `--failfast` to stop after the first validation failure, whether it comes from registry assembly, `@property` validation, or declaration usage validation. Exit codes and human/JSON output formats are unchanged.
+
+## Generate Registrations
+
+The experimental `generate` command writes inferred `@property` rules to `properties.css` by default:
+
+```bash
+css-property-type-validator generate "src/**/*.css"
+```
+
+Use `--out <path>` to specify another file, `--force` to overwrite an existing output file, and `--format json` to inspect generated and review-needed candidates.
+
+Generation needs concrete authored custom property declarations:
+
+```css
+:root {
+  --brand-color: red;
+  --space: 1px;
+}
+```
+
+`var()` usage sites are optional. Alias tokens such as `--border-color: var(--brand-color)` can generate only when the referenced token declarations are also passed to the command. If the generator only sees aliases and not the concrete primitive values they point to, those aliases are returned as review items.
 
 ## Exit Codes
 

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -1,14 +1,16 @@
 #!/usr/bin/env node
 
-import { readFileSync } from "node:fs";
-import { glob, readFile } from "node:fs/promises";
+import { existsSync, readFileSync } from "node:fs";
+import { glob, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import process from "node:process";
+import { parseArgs } from "node:util";
 
 import { Command } from "commander";
 
 import {
   formatValidationResult,
+  generatePropertyRegistrations,
   validateFiles,
   type OutputFormat,
 } from "@schalkneethling/css-property-type-validator-core";
@@ -25,6 +27,89 @@ interface CliOptions {
   registry: string[];
   registryOnly: boolean;
   tokens: string[];
+}
+
+interface GenerateOptions {
+  force: boolean;
+  format: "css" | "json";
+  out: string;
+}
+
+function parseGenerateArguments(args: string[]): { options: GenerateOptions; patterns: string[] } {
+  const parsed = parseArgs({
+    allowPositionals: true,
+    args,
+    options: {
+      force: { type: "boolean" },
+      format: { type: "string" },
+      out: { type: "string" },
+    },
+    strict: true,
+  });
+  const format = parsed.values.format === "json" ? "json" : "css";
+  const force = typeof parsed.values.force === "boolean" ? parsed.values.force : false;
+  const out = typeof parsed.values.out === "string" ? parsed.values.out : "properties.css";
+
+  return {
+    options: {
+      force,
+      format,
+      out,
+    },
+    patterns: parsed.positionals,
+  };
+}
+
+function pluralize(count: number, singular: string, plural = `${singular}s`): string {
+  const pluralRules = new Intl.PluralRules("en");
+  return pluralRules.select(count) === "one" ? singular : plural;
+}
+
+async function runGenerateCommand(args: string[]): Promise<void> {
+  const { options, patterns } = parseGenerateArguments(args);
+  const inputs = await loadInputs(patterns);
+
+  if (!inputs.length) {
+    process.stderr.write(
+      "No CSS files matched the generation patterns. Pass one or more CSS files or glob patterns.\n",
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  const result = generatePropertyRegistrations(inputs, { outFile: options.out });
+
+  if (options.format === "json") {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
+    return;
+  }
+
+  if (existsSync(options.out) && !options.force) {
+    process.stderr.write(
+      `${options.out} already exists. Use --force to overwrite it or --out to specify another file.\n`,
+    );
+    process.exitCode = 2;
+    return;
+  }
+
+  await writeFile(options.out, result.css, "utf8");
+
+  process.stdout.write(
+    `Generated ${result.generatedCount} @property ${pluralize(result.generatedCount, "registration")} in ${options.out}.\n`,
+  );
+
+  if (result.reviewCount > 0 || result.diagnostics.length > 0) {
+    process.stdout.write(
+      `Review ${result.reviewCount} ${pluralize(result.reviewCount, "item")} with --format json. Share feedback at https://github.com/schalkneethling/css-property-type-validator/issues/98\n`,
+    );
+  } else {
+    process.stdout.write(
+      "Share feedback at https://github.com/schalkneethling/css-property-type-validator/issues/98\n",
+    );
+  }
+
+  process.exitCode = result.diagnostics.length > 0 ? 1 : 0;
 }
 
 async function loadInputs(patterns: string[]): Promise<ValidationInput[]> {
@@ -104,11 +189,20 @@ async function loadKnownCustomPropertyInputs(options: CliOptions): Promise<Valid
 }
 
 async function main(): Promise<void> {
+  if (process.argv[2] === "generate") {
+    await runGenerateCommand(process.argv.slice(3));
+    return;
+  }
+
   const program = new Command();
 
   program
     .name("css-property-type-validator")
     .description("Validate @property registrations and var() usages across CSS files.")
+    .addHelpText(
+      "after",
+      "\nCommands:\n  generate [options] <patterns...>  Experimentally generate @property registrations from existing CSS.",
+    )
     .argument("[patterns...]", "CSS files or glob patterns to validate")
     .option("-f, --format <format>", "output format: human or json", "human")
     .option("--failfast", "stop after the first validation failure", false)

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -46,9 +46,17 @@ function parseGenerateArguments(args: string[]): { options: GenerateOptions; pat
     },
     strict: true,
   });
-  const format = parsed.values.format === "json" ? "json" : "css";
+  const requestedFormat = parsed.values.format;
+  const format =
+    requestedFormat === undefined || requestedFormat === "css" || requestedFormat === "json"
+      ? (requestedFormat ?? "css")
+      : null;
   const force = typeof parsed.values.force === "boolean" ? parsed.values.force : false;
   const out = typeof parsed.values.out === "string" ? parsed.values.out : "properties.css";
+
+  if (!format) {
+    throw new Error(`Unsupported generate format "${requestedFormat}". Use "css" or "json".`);
+  }
 
   return {
     options: {

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -48,6 +48,30 @@ const result = validateFiles(
 console.log(result.diagnostics);
 ```
 
+## Generate Registrations
+
+Use `generatePropertyRegistrations` to infer conservative `@property` rules from existing custom property declarations:
+
+```ts
+import { generatePropertyRegistrations } from "@schalkneethling/css-property-type-validator-core";
+
+const result = generatePropertyRegistrations([
+  {
+    path: "tokens.css",
+    css: `
+      :root {
+        --brand-color: red;
+        --space: 1px;
+      }
+    `,
+  },
+]);
+
+console.log(result.css);
+```
+
+Generation needs concrete declarations such as `--brand-color: red`. `var()` usage sites are optional. Alias values such as `--border-color: var(--brand-color)` can generate only when the referenced token declarations are included in the same inputs.
+
 Diagnostics include stable machine-readable fields for tooling integrations:
 
 ```ts

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -1,0 +1,406 @@
+import * as cssTree from "css-tree";
+
+import { validateInitialValueAgainstSyntax } from "./registry.js";
+import { SUPPORTED_SYNTAX_COMPONENT_NAMES } from "./supported-syntax.js";
+import { validateFiles } from "./validate.js";
+
+import type { CssAtruleNode } from "./imports.js";
+import type { SourceLocation, ValidationDiagnostic, ValidationInput } from "./types.js";
+
+export type GeneratedPropertyStatus =
+  | "generated"
+  | "existing"
+  | "conflict"
+  | "unsupported"
+  | "invalid-generated";
+
+export interface GeneratedPropertyCandidate {
+  initialValue?: string;
+  loc: SourceLocation | null;
+  name: string;
+  observedValues: string[];
+  reason?: string;
+  sources: string[];
+  status: GeneratedPropertyStatus;
+  syntax?: string;
+}
+
+export interface GeneratePropertyRegistrationsResult {
+  candidates: GeneratedPropertyCandidate[];
+  css: string;
+  diagnostics: ValidationDiagnostic[];
+  generatedCount: number;
+  reviewCount: number;
+}
+
+interface CssLocation {
+  source?: string;
+  start: SourceLocation["start"];
+  end: SourceLocation["end"];
+}
+
+interface CssDeclarationNode {
+  loc?: unknown;
+  property: string;
+  value?: unknown;
+}
+
+interface CssFunctionNode {
+  children?: ArrayLike<unknown> & { toArray?: () => CssValueNode[] };
+  name?: string;
+  type?: string;
+}
+
+interface CssPropertyNameNode {
+  name?: string;
+}
+
+interface ParsedStylesheet {
+  children?: ArrayLike<unknown>;
+}
+
+interface CssValueNode {
+  name?: string;
+  type?: string;
+  value?: string;
+}
+
+interface ObservedProperty {
+  loc: SourceLocation | null;
+  sources: Set<string>;
+  values: Set<string>;
+}
+
+interface ResolvedValues {
+  unresolvedAliases: string[];
+  values: string[];
+}
+
+function toLocation(loc: unknown): SourceLocation | null {
+  if (!loc) {
+    return null;
+  }
+
+  const typedLoc = loc as CssLocation;
+
+  return {
+    source: typedLoc.source,
+    start: { ...typedLoc.start },
+    end: { ...typedLoc.end },
+  };
+}
+
+function parseValue(value: string): unknown | null {
+  try {
+    return cssTree.parse(value, { context: "value" });
+  } catch {
+    return null;
+  }
+}
+
+function matchSyntax(syntax: string, value: unknown): boolean {
+  const match = cssTree.lexer.match(syntax, value);
+  return Boolean(match?.matched);
+}
+
+function valueChildren(value: unknown): CssValueNode[] {
+  const children = (value as { children?: ArrayLike<unknown> & { toArray?: () => CssValueNode[] } })
+    .children;
+
+  if (!children) {
+    return [];
+  }
+
+  return children.toArray?.() ?? (Array.from(children) as CssValueNode[]);
+}
+
+function functionChildren(node: CssFunctionNode): CssValueNode[] {
+  const children = node.children;
+
+  if (!children) {
+    return [];
+  }
+
+  return children.toArray?.() ?? (Array.from(children) as CssValueNode[]);
+}
+
+function exactVarReference(value: string): string | null {
+  const parsedValue = parseValue(value);
+
+  if (!parsedValue) {
+    return null;
+  }
+
+  const [node] = valueChildren(parsedValue) as CssFunctionNode[];
+
+  if (!node || node.type !== "Function" || node.name !== "var") {
+    return null;
+  }
+
+  const children = functionChildren(node);
+  const [firstChild] = children;
+  const hasFallback = children.some((child) => child.type === "Operator" && child.value === ",");
+
+  return !hasFallback && firstChild?.type === "Identifier" ? (firstChild.name ?? null) : null;
+}
+
+function resolveObservedValues(
+  propertyName: string,
+  observed: Map<string, ObservedProperty>,
+  activeProperties = new Set<string>(),
+): ResolvedValues {
+  if (activeProperties.has(propertyName)) {
+    return { unresolvedAliases: [propertyName], values: [] };
+  }
+
+  const entry = observed.get(propertyName);
+
+  if (!entry) {
+    return { unresolvedAliases: [propertyName], values: [] };
+  }
+
+  activeProperties.add(propertyName);
+
+  const unresolvedAliases = new Set<string>();
+  const values = new Set<string>();
+
+  for (const value of entry.values) {
+    const referencedProperty = exactVarReference(value);
+
+    if (!referencedProperty) {
+      values.add(value);
+      continue;
+    }
+
+    const resolved = resolveObservedValues(referencedProperty, observed, activeProperties);
+
+    for (const resolvedValue of resolved.values) {
+      values.add(resolvedValue);
+    }
+
+    for (const unresolvedAlias of resolved.unresolvedAliases) {
+      unresolvedAliases.add(unresolvedAlias);
+    }
+  }
+
+  activeProperties.delete(propertyName);
+
+  return {
+    unresolvedAliases: [...unresolvedAliases],
+    values: [...values],
+  };
+}
+
+function inferSyntax(values: string[]): string | null {
+  if (values.length === 0) {
+    return null;
+  }
+
+  const parsedValues = values.map(parseValue);
+
+  if (parsedValues.some((value) => !value)) {
+    return null;
+  }
+
+  return (
+    SUPPORTED_SYNTAX_COMPONENT_NAMES.find((syntax) =>
+      parsedValues.every((value) => matchSyntax(syntax, value)),
+    ) ?? null
+  );
+}
+
+function firstValidInitialValue(values: string[], syntax: string): string | null {
+  for (const value of values) {
+    if (validateInitialValueAgainstSyntax("--generated", syntax, value) === null) {
+      return value;
+    }
+  }
+
+  return null;
+}
+
+function propertyRuleName(node: CssAtruleNode): string | null {
+  const [propertyName] = Array.from(node.prelude?.children ?? []) as CssPropertyNameNode[];
+  return propertyName?.name ?? null;
+}
+
+function collectInput(
+  input: ValidationInput,
+  observed: Map<string, ObservedProperty>,
+  existing: Set<string>,
+  diagnostics: ValidationDiagnostic[],
+): void {
+  let ast: ParsedStylesheet;
+
+  try {
+    ast = cssTree.parse(input.css, { filename: input.path, positions: true }) as ParsedStylesheet;
+  } catch (error) {
+    diagnostics.push({
+      code: "unparseable-stylesheet",
+      filePath: input.path,
+      loc: null,
+      message: `Could not parse ${input.path}: ${(error as Error).message}`,
+      phase: "parse",
+      reason: "unparseable-css",
+      severity: "error",
+    });
+    return;
+  }
+
+  for (const node of Array.from(ast.children ?? []) as CssAtruleNode[]) {
+    if (node.type === "Atrule" && node.name === "property") {
+      const name = propertyRuleName(node);
+
+      if (name) {
+        existing.add(name);
+      }
+    }
+  }
+
+  cssTree.walk(ast, {
+    visit: "Declaration",
+    enter(node: CssDeclarationNode) {
+      if (!node.property.startsWith("--") || !node.value) {
+        return;
+      }
+
+      const value = cssTree.generate(node.value).trim();
+      const entry =
+        observed.get(node.property) ??
+        ({
+          loc: toLocation(node.loc),
+          sources: new Set<string>(),
+          values: new Set<string>(),
+        } satisfies ObservedProperty);
+
+      entry.sources.add(input.path);
+      entry.values.add(value);
+
+      observed.set(node.property, entry);
+    },
+  });
+}
+
+function formatPropertyRule(candidate: GeneratedPropertyCandidate): string {
+  return [
+    `@property ${candidate.name} {`,
+    `  syntax: "${candidate.syntax}";`,
+    "  inherits: true;",
+    `  initial-value: ${candidate.initialValue};`,
+    "}",
+  ].join("\n");
+}
+
+/**
+ * Generates conservative `@property` registration candidates from authored custom property
+ * declarations. Existing registrations are reported but left unchanged, ready candidates are
+ * validated with the same registry checks used by the validator, and ambiguous or unsafe values
+ * are returned as review items instead of being emitted in the generated CSS.
+ */
+export function generatePropertyRegistrations(
+  inputs: ValidationInput[],
+  options: { outFile?: string } = {},
+): GeneratePropertyRegistrationsResult {
+  const diagnostics: ValidationDiagnostic[] = [];
+  const existing = new Set<string>();
+  const observed = new Map<string, ObservedProperty>();
+  const candidates: GeneratedPropertyCandidate[] = [];
+
+  for (const input of inputs) {
+    collectInput(input, observed, existing, diagnostics);
+  }
+
+  const sortedObservedEntries = [...observed.entries()].toSorted(([left], [right]) =>
+    left.localeCompare(right),
+  );
+
+  for (const [name, entry] of sortedObservedEntries) {
+    const observedValues = [...entry.values];
+    const resolvedValues = resolveObservedValues(name, observed);
+    const baseCandidate = {
+      loc: entry.loc,
+      name,
+      observedValues,
+      sources: [...entry.sources].sort(),
+    };
+
+    if (existing.has(name)) {
+      candidates.push({
+        ...baseCandidate,
+        reason: "Existing @property rule found in the input.",
+        status: "existing",
+      });
+      continue;
+    }
+
+    const syntax = inferSyntax(resolvedValues.values);
+
+    if (!syntax) {
+      const unresolvedAliases = resolvedValues.unresolvedAliases.join(", ");
+      candidates.push({
+        ...baseCandidate,
+        reason:
+          unresolvedAliases.length > 0
+            ? `Observed values are aliases through var(). Include declarations for ${unresolvedAliases} so the generator can infer a concrete syntax.`
+            : "Observed values do not share one supported syntax.",
+        status: "conflict",
+      });
+      continue;
+    }
+
+    const initialValue = firstValidInitialValue(resolvedValues.values, syntax);
+
+    if (!initialValue) {
+      candidates.push({
+        ...baseCandidate,
+        reason: "No observed value is valid as a computationally independent initial-value.",
+        status: "unsupported",
+        syntax,
+      });
+      continue;
+    }
+
+    candidates.push({
+      ...baseCandidate,
+      initialValue,
+      status: "generated",
+      syntax,
+    });
+  }
+
+  const generatedRules = candidates.filter(
+    (
+      candidate,
+    ): candidate is GeneratedPropertyCandidate & { initialValue: string; syntax: string } =>
+      candidate.status === "generated",
+  );
+  const generatedCss = generatedRules.map(formatPropertyRule).join("\n\n");
+  const validationResult =
+    generatedCss.length > 0
+      ? validateFiles([{ path: options.outFile ?? "properties.css", css: generatedCss }], {
+          registryInputs: [],
+        })
+      : { diagnostics: [] };
+
+  if (validationResult.diagnostics.length > 0) {
+    diagnostics.push(...validationResult.diagnostics);
+
+    for (const candidate of generatedRules) {
+      candidate.status = "invalid-generated";
+      candidate.reason = "Generated registration failed validation.";
+    }
+  }
+
+  const readyCss = candidates
+    .filter((candidate) => candidate.status === "generated")
+    .map(formatPropertyRule)
+    .join("\n\n");
+
+  return {
+    candidates,
+    css: readyCss.length > 0 ? `${readyCss}\n` : "",
+    diagnostics,
+    generatedCount: candidates.filter((candidate) => candidate.status === "generated").length,
+    reviewCount: candidates.filter((candidate) => candidate.status !== "generated").length,
+  };
+}

--- a/packages/core/src/generate.ts
+++ b/packages/core/src/generate.ts
@@ -131,9 +131,10 @@ function exactVarReference(value: string): string | null {
     return null;
   }
 
-  const [node] = valueChildren(parsedValue) as CssFunctionNode[];
+  const nodes = valueChildren(parsedValue);
+  const [node] = nodes as CssFunctionNode[];
 
-  if (!node || node.type !== "Function" || node.name !== "var") {
+  if (nodes.length !== 1 || !node || node.type !== "Function" || node.name !== "var") {
     return null;
   }
 
@@ -333,6 +334,16 @@ export function generatePropertyRegistrations(
       continue;
     }
 
+    if (resolvedValues.unresolvedAliases.length > 0) {
+      const unresolvedAliases = resolvedValues.unresolvedAliases.join(", ");
+      candidates.push({
+        ...baseCandidate,
+        reason: `Observed values include aliases through var(). Include declarations for ${unresolvedAliases} so the generator can infer a complete concrete syntax.`,
+        status: "conflict",
+      });
+      continue;
+    }
+
     const syntax = inferSyntax(resolvedValues.values);
 
     if (!syntax) {
@@ -385,7 +396,17 @@ export function generatePropertyRegistrations(
   if (validationResult.diagnostics.length > 0) {
     diagnostics.push(...validationResult.diagnostics);
 
+    const invalidPropertyNames = new Set(
+      validationResult.diagnostics
+        .map((diagnostic) => diagnostic.propertyName)
+        .filter((propertyName): propertyName is string => Boolean(propertyName)),
+    );
+
     for (const candidate of generatedRules) {
+      if (!invalidPropertyNames.has(candidate.name)) {
+        continue;
+      }
+
       candidate.status = "invalid-generated";
       candidate.reason = "Generated registration failed validation.";
     }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,5 +1,11 @@
 export { validateFiles } from "./validate.js";
 export type { ValidateFilesOptions } from "./validate.js";
+export { generatePropertyRegistrations } from "./generate.js";
+export type {
+  GeneratedPropertyCandidate,
+  GeneratedPropertyStatus,
+  GeneratePropertyRegistrationsResult,
+} from "./generate.js";
 export { formatValidationResult } from "./formatter.js";
 export type { OutputFormat } from "./formatter.js";
 export { isAbsoluteImportUrl } from "./imports.js";

--- a/packages/core/src/registry.ts
+++ b/packages/core/src/registry.ts
@@ -190,7 +190,7 @@ function getComputationalIndependenceFailureReason(value: unknown): string | nul
   return failure;
 }
 
-function validateInitialValueAgainstSyntax(
+export function validateInitialValueAgainstSyntax(
   propertyName: string,
   syntax: string,
   initialValue: string,

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -103,4 +103,45 @@ describe("generatePropertyRegistrations", () => {
     expect(result.candidates[0]?.status).toBe("conflict");
     expect(result.candidates[0]?.reason).toContain("Include declarations for --brand-color");
   });
+
+  it("does not treat multi-token var() values as exact aliases", () => {
+    const result = generatePropertyRegistrations([
+      {
+        path: "/tmp/tokens.css",
+        css: ":root { --border: var(--brand-color) solid; --brand-color: red; }",
+      },
+    ]);
+
+    const border = result.candidates.find((candidate) => candidate.name === "--border");
+
+    expect(border?.status).toBe("conflict");
+    expect(border?.reason).toContain("do not share one supported syntax");
+  });
+
+  it("keeps resolved aliases generated when unrelated aliases are unresolved", () => {
+    const result = generatePropertyRegistrations([
+      {
+        path: "/tmp/tokens.css",
+        css: [
+          ":root {",
+          "  --known: red;",
+          "  --known-alias: var(--known);",
+          "  --unknown-alias: var(--unknown);",
+          "}",
+        ].join("\n"),
+      },
+    ]);
+
+    const knownAlias = result.candidates.find((candidate) => candidate.name === "--known-alias");
+    const unknownAlias = result.candidates.find(
+      (candidate) => candidate.name === "--unknown-alias",
+    );
+
+    expect(knownAlias?.status).toBe("generated");
+    expect(knownAlias?.syntax).toBe("<color>");
+    expect(knownAlias?.initialValue).toBe("red");
+    expect(result.css).toContain("@property --known-alias");
+    expect(unknownAlias?.status).toBe("conflict");
+    expect(unknownAlias?.reason).toContain("--unknown");
+  });
 });

--- a/packages/core/test/generate.test.ts
+++ b/packages/core/test/generate.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from "vitest";
+
+import { generatePropertyRegistrations } from "../src/index.js";
+
+describe("generatePropertyRegistrations", () => {
+  it("generates conservative property registrations from custom property values", () => {
+    const result = generatePropertyRegistrations([
+      {
+        path: "/tmp/tokens.css",
+        css: ":root { --brand-color: rebeccapurple; --space: 1px; }",
+      },
+    ]);
+
+    expect(result.css).toContain('@property --brand-color {\n  syntax: "<color>";');
+    expect(result.css).toContain("@property --space");
+    expect(result.css).toContain("inherits: true;");
+    expect(result.generatedCount).toBe(2);
+    expect(result.diagnostics).toHaveLength(0);
+  });
+
+  it("dedupes observed values across multiple inputs", () => {
+    const result = generatePropertyRegistrations([
+      { path: "/tmp/a.css", css: ":root { --space: 1rem; }" },
+      { path: "/tmp/b.css", css: ".card { --space: 1rem; }" },
+    ]);
+
+    expect(result.candidates).toHaveLength(1);
+    expect(result.candidates[0]?.observedValues).toEqual(["1rem"]);
+    expect(result.candidates[0]?.sources).toEqual(["/tmp/a.css", "/tmp/b.css"]);
+  });
+
+  it("leaves existing property rules untouched and reports them as existing", () => {
+    const result = generatePropertyRegistrations([
+      {
+        path: "/tmp/tokens.css",
+        css: [
+          '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: red; }',
+          ":root { --brand-color: blue; }",
+        ].join("\n"),
+      },
+    ]);
+
+    expect(result.css).toBe("");
+    expect(result.candidates[0]?.status).toBe("existing");
+    expect(result.candidates[0]?.reason).toContain("Existing @property");
+  });
+
+  it("reports conflicting values instead of guessing", () => {
+    const result = generatePropertyRegistrations([
+      { path: "/tmp/tokens.css", css: ":root { --token: 1rem; }\n.card { --token: red; }" },
+    ]);
+
+    expect(result.css).toBe("");
+    expect(result.candidates[0]?.status).toBe("conflict");
+    expect(result.reviewCount).toBe(1);
+  });
+
+  it("reports parse failures without stopping other inputs", () => {
+    const result = generatePropertyRegistrations([
+      { path: "/tmp/broken.css", css: null as unknown as string },
+      { path: "/tmp/tokens.css", css: ":root { --brand-color: red; }" },
+    ]);
+
+    expect(result.diagnostics[0]?.code).toBe("unparseable-stylesheet");
+    expect(result.generatedCount).toBe(1);
+  });
+
+  it("does not emit candidates without a computationally independent initial value", () => {
+    const result = generatePropertyRegistrations([
+      { path: "/tmp/tokens.css", css: ":root { --font-size: 1em; }" },
+    ]);
+
+    expect(result.css).toBe("");
+    expect(result.candidates[0]?.status).toBe("unsupported");
+    expect(result.candidates[0]?.reason).toContain("computationally independent");
+  });
+
+  it("resolves exact var() aliases when referenced custom properties are provided", () => {
+    const result = generatePropertyRegistrations([
+      {
+        path: "/tmp/tokens.css",
+        css: ":root { --brand-color: red; --border-color: var(--brand-color); }",
+      },
+    ]);
+
+    const borderColor = result.candidates.find((candidate) => candidate.name === "--border-color");
+
+    expect(borderColor?.status).toBe("generated");
+    expect(borderColor?.syntax).toBe("<color>");
+    expect(borderColor?.initialValue).toBe("red");
+    expect(result.css).toContain("@property --border-color");
+  });
+
+  it("reports unresolved exact var() aliases with a concrete review reason", () => {
+    const result = generatePropertyRegistrations([
+      {
+        path: "/tmp/tokens.css",
+        css: ":root { --border-color: var(--brand-color); }",
+      },
+    ]);
+
+    expect(result.css).toBe("");
+    expect(result.candidates[0]?.status).toBe("conflict");
+    expect(result.candidates[0]?.reason).toContain("Include declarations for --brand-color");
+  });
+});

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -1320,6 +1320,29 @@ describe("validateFiles", () => {
     expect(readFileSync(outputPath, "utf8")).toBe("keep me\n");
   });
 
+  it("overwrites existing generated output when --force is passed", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const inputPath = path.join(fixtureDir, "tokens.css");
+    const outputPath = path.join(fixtureDir, "properties.css");
+
+    writeFileSync(inputPath, ":root { --brand-color: red; }\n");
+    writeFileSync(outputPath, "keep me\n");
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", "generate", inputPath, "--out", outputPath, "--force"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(0);
+    expect(readFileSync(outputPath, "utf8")).not.toBe("keep me\n");
+    expect(readFileSync(outputPath, "utf8")).toContain("@property --brand-color");
+  });
+
   it("prints structured generation output as JSON", { timeout: 120000 }, () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../..");
     const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
@@ -1339,6 +1362,26 @@ describe("validateFiles", () => {
 
     expect(cliResult.status).toBe(0);
     expect(report.generatedCount).toBe(1);
+  });
+
+  it("rejects unsupported generation output formats", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const inputPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(inputPath, ":root { --brand-color: red; }\n");
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", "generate", inputPath, "--format", "jsoon"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(2);
+    expect(cliResult.stderr).toContain('Unsupported generate format "jsoon"');
   });
 
   it("keeps human CLI output stable for a clean validation run", { timeout: 120000 }, () => {

--- a/packages/core/test/validate-files.test.ts
+++ b/packages/core/test/validate-files.test.ts
@@ -1268,6 +1268,79 @@ describe("validateFiles", () => {
     expect(cliResult.stdout).toContain("--failfast");
   });
 
+  it(
+    "writes generated @property registrations with the experimental CLI command",
+    {
+      timeout: 120000,
+    },
+    () => {
+      const repoRoot = path.resolve(import.meta.dirname, "../../..");
+      const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+      const inputPath = path.join(fixtureDir, "tokens.css");
+      const outputPath = path.join(fixtureDir, "properties.css");
+
+      writeFileSync(inputPath, ":root { --brand-color: red; --space: 1px; }\n");
+
+      const cliResult = spawnSync(
+        "node",
+        ["packages/cli/dist/cli.js", "generate", inputPath, "--out", outputPath],
+        {
+          cwd: repoRoot,
+          encoding: "utf8",
+        },
+      );
+
+      expect(cliResult.status).toBe(0);
+      expect(cliResult.stdout).toContain("Generated 2 @property registrations");
+      expect(readFileSync(outputPath, "utf8")).toContain("@property --brand-color");
+      expect(readFileSync(outputPath, "utf8")).toContain("@property --space");
+    },
+  );
+
+  it("protects existing generated output unless --force is passed", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const inputPath = path.join(fixtureDir, "tokens.css");
+    const outputPath = path.join(fixtureDir, "properties.css");
+
+    writeFileSync(inputPath, ":root { --brand-color: red; }\n");
+    writeFileSync(outputPath, "keep me\n");
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", "generate", inputPath, "--out", outputPath],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+
+    expect(cliResult.status).toBe(2);
+    expect(cliResult.stderr).toContain("already exists");
+    expect(readFileSync(outputPath, "utf8")).toBe("keep me\n");
+  });
+
+  it("prints structured generation output as JSON", { timeout: 120000 }, () => {
+    const repoRoot = path.resolve(import.meta.dirname, "../../..");
+    const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));
+    const inputPath = path.join(fixtureDir, "tokens.css");
+
+    writeFileSync(inputPath, ":root { --brand-color: red; }\n");
+
+    const cliResult = spawnSync(
+      "node",
+      ["packages/cli/dist/cli.js", "generate", inputPath, "--format", "json"],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+      },
+    );
+    const report = JSON.parse(cliResult.stdout) as { generatedCount: number };
+
+    expect(cliResult.status).toBe(0);
+    expect(report.generatedCount).toBe(1);
+  });
+
   it("keeps human CLI output stable for a clean validation run", { timeout: 120000 }, () => {
     const repoRoot = path.resolve(import.meta.dirname, "../../..");
     const fixtureDir = mkdtempSync(path.join(tmpdir(), "css-property-validator-"));

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2023",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
     "strict": true,

--- a/web/index.html
+++ b/web/index.html
@@ -56,6 +56,24 @@
         </div>
         <section class="header-actions" aria-labelledby="header-actions-title">
           <h2 class="visually-hidden" id="header-actions-title">Validation actions</h2>
+          <fieldset class="mode-toggle">
+            <legend>Mode</legend>
+            <label for="mode-validate">
+              <input
+                id="mode-validate"
+                class="js-mode"
+                type="radio"
+                name="mode"
+                value="validate"
+                checked
+              />
+              <span>Validate</span>
+            </label>
+            <label for="mode-generate">
+              <input id="mode-generate" class="js-mode" type="radio" name="mode" value="generate" />
+              <span>Generate</span>
+            </label>
+          </fieldset>
           <label class="check-toggle" for="unknown-custom-properties-input">
             <input
               id="unknown-custom-properties-input"
@@ -78,9 +96,16 @@
           </label>
           <label class="file-button" for="css-file-input">
             <span>Open CSS</span>
-            <input id="css-file-input" class="js-file-input" type="file" accept=".css,text/css" />
+            <input
+              id="css-file-input"
+              class="js-file-input"
+              type="file"
+              accept=".css,text/css"
+              multiple
+            />
           </label>
           <button class="primary-action js-validate-button" type="button">Validate</button>
+          <button class="primary-action js-generate-button" type="button" hidden>Generate</button>
         </section>
       </header>
 
@@ -107,7 +132,7 @@
             <div class="panel-header output-header">
               <div>
                 <p class="panel-kicker">Output</p>
-                <h2 id="output-title">Validation result</h2>
+                <h2 id="output-title" class="js-output-title">Validation result</h2>
               </div>
               <fieldset class="format-toggle">
                 <legend>Output format</legend>
@@ -146,19 +171,19 @@
               <h3 class="visually-hidden" id="validation-summary-title">Validation summary</h3>
               <dl class="result-stats" aria-live="polite">
                 <div>
-                  <dt>Diagnostics</dt>
+                  <dt class="js-stat-diagnostics-label">Diagnostics</dt>
                   <dd class="js-stat-diagnostics">—</dd>
                 </div>
                 <div>
-                  <dt>Registered</dt>
+                  <dt class="js-stat-registered-label">Registered</dt>
                   <dd class="js-stat-registered">—</dd>
                 </div>
                 <div>
-                  <dt>Validated</dt>
+                  <dt class="js-stat-validated-label">Validated</dt>
                   <dd class="js-stat-validated">—</dd>
                 </div>
                 <div>
-                  <dt>Skipped</dt>
+                  <dt class="js-stat-skipped-label">Skipped</dt>
                   <dd class="js-stat-skipped">—</dd>
                 </div>
               </dl>

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,6 +1,8 @@
 import {
   formatValidationResult,
+  generatePropertyRegistrations,
   validateFiles,
+  type GeneratePropertyRegistrationsResult,
   type OutputFormat,
   type ValidationInput,
   type ValidationResult,
@@ -8,7 +10,7 @@ import {
 
 import "./components/code-editor.js";
 
-const DEFAULT_CSS = `@property --brand-color {
+const VALIDATION_DEFAULT_CSS = `@property --brand-color {
   syntax: "<color>";
   inherits: true;
   initial-value: transparent;
@@ -18,7 +20,21 @@ const DEFAULT_CSS = `@property --brand-color {
   inline-size: var(--brand-color);
 }`;
 
+const GENERATION_DEFAULT_CSS = `:root {
+  --brand-color: red;
+  --space: 1px;
+}
+
+.card {
+  color: var(--brand-color);
+  inline-size: var(--space);
+}`;
+
 const INITIAL_OUTPUT = "Run validation to see diagnostics here.";
+const INITIAL_GENERATION_OUTPUT = "Generate registrations to preview properties.css here.";
+const FEEDBACK_URL = "https://github.com/schalkneethling/css-property-type-validator/issues/98";
+
+type AppMode = "validate" | "generate";
 
 interface CodeEditorElement extends HTMLElement {
   language: "css" | "json" | "text";
@@ -48,10 +64,13 @@ function tokenInputPath(file: File, index: number): string {
 }
 
 class ValidatorController extends HTMLElement {
-  #cssSource = DEFAULT_CSS;
+  #cssSource = VALIDATION_DEFAULT_CSS;
   #fileName = "pasted.css";
+  #fileInputs: ValidationInput[] = [];
   #checkUnknownCustomProperties = false;
+  #mode: AppMode = "validate";
   #outputFormat: OutputFormat = "human";
+  #generationResult: GeneratePropertyRegistrationsResult | null = null;
   #result: ValidationResult | null = null;
   #tokenInputs: ValidationInput[] = [];
 
@@ -59,13 +78,20 @@ class ValidatorController extends HTMLElement {
   #checkUnknownCustomPropertiesInput: HTMLInputElement | null = null;
   #fileInput: HTMLInputElement | null = null;
   #fileNameElement: HTMLElement | null = null;
+  #generateButton: HTMLButtonElement | null = null;
   #inputEditor: CodeEditorElement | null = null;
+  #modeInputs: HTMLInputElement[] = [];
   #outputEditor: CodeEditorElement | null = null;
   #outputFormatInputs: HTMLInputElement[] = [];
+  #outputTitle: HTMLElement | null = null;
   #statDiagnostics: HTMLElement | null = null;
+  #statDiagnosticsLabel: HTMLElement | null = null;
   #statRegistered: HTMLElement | null = null;
+  #statRegisteredLabel: HTMLElement | null = null;
   #statSkipped: HTMLElement | null = null;
+  #statSkippedLabel: HTMLElement | null = null;
   #statValidated: HTMLElement | null = null;
+  #statValidatedLabel: HTMLElement | null = null;
   #tokenFileInput: HTMLInputElement | null = null;
   #validationStatus: HTMLElement | null = null;
   #validateButton: HTMLButtonElement | null = null;
@@ -89,15 +115,22 @@ class ValidatorController extends HTMLElement {
     );
     this.#fileInput = queryElement<HTMLInputElement>(this, ".js-file-input");
     this.#fileNameElement = queryElement<HTMLElement>(this, ".js-file-name");
+    this.#generateButton = queryElement<HTMLButtonElement>(this, ".js-generate-button");
     this.#inputEditor = queryElement<CodeEditorElement>(this, ".js-input-editor");
+    this.#modeInputs = Array.from(this.querySelectorAll<HTMLInputElement>(".js-mode"));
     this.#outputEditor = queryElement<CodeEditorElement>(this, ".js-output-editor");
     this.#outputFormatInputs = Array.from(
       this.querySelectorAll<HTMLInputElement>(".js-output-format"),
     );
+    this.#outputTitle = queryElement<HTMLElement>(this, ".js-output-title");
     this.#statDiagnostics = queryElement<HTMLElement>(this, ".js-stat-diagnostics");
+    this.#statDiagnosticsLabel = queryElement<HTMLElement>(this, ".js-stat-diagnostics-label");
     this.#statRegistered = queryElement<HTMLElement>(this, ".js-stat-registered");
+    this.#statRegisteredLabel = queryElement<HTMLElement>(this, ".js-stat-registered-label");
     this.#statSkipped = queryElement<HTMLElement>(this, ".js-stat-skipped");
+    this.#statSkippedLabel = queryElement<HTMLElement>(this, ".js-stat-skipped-label");
     this.#statValidated = queryElement<HTMLElement>(this, ".js-stat-validated");
+    this.#statValidatedLabel = queryElement<HTMLElement>(this, ".js-stat-validated-label");
     this.#tokenFileInput = queryElement<HTMLInputElement>(this, ".js-token-file-input");
     this.#validationStatus = queryElement<HTMLElement>(this, ".js-validation-status");
     this.#validateButton = queryElement<HTMLButtonElement>(this, ".js-validate-button");
@@ -112,6 +145,7 @@ class ValidatorController extends HTMLElement {
     outputEditor.value = INITIAL_OUTPUT;
     fileNameElement.textContent = this.#fileName;
     requireCachedValue(this.#tokenFileInput, "token file input").disabled = true;
+    this.#renderMode();
   }
 
   #addEventListeners(): void {
@@ -121,6 +155,7 @@ class ValidatorController extends HTMLElement {
       "unknown custom properties input",
     );
     const fileInput = requireCachedValue(this.#fileInput, "file input");
+    const generateButton = requireCachedValue(this.#generateButton, "generate button");
     const inputEditor = requireCachedValue(this.#inputEditor, "input editor");
     const tokenFileInput = requireCachedValue(this.#tokenFileInput, "token file input");
     const validateButton = requireCachedValue(this.#validateButton, "validate button");
@@ -132,6 +167,7 @@ class ValidatorController extends HTMLElement {
       { signal },
     );
     fileInput.addEventListener("change", this.#handleFileSelection, { signal });
+    generateButton.addEventListener("click", this.#generateCss, { signal });
     inputEditor.addEventListener("editor-change", this.#handleEditorChange, { signal });
     tokenFileInput.addEventListener("change", this.#handleTokenFileSelection, { signal });
     validateButton.addEventListener("click", this.#validateCss, { signal });
@@ -139,10 +175,17 @@ class ValidatorController extends HTMLElement {
     for (const input of this.#outputFormatInputs) {
       input.addEventListener("change", this.#handleFormatChange, { signal });
     }
+
+    for (const input of this.#modeInputs) {
+      input.addEventListener("change", this.#handleModeChange, { signal });
+    }
   }
 
   #handleEditorChange = (event: Event): void => {
     this.#cssSource = (event as CustomEvent<string>).detail;
+    this.#fileInputs = [];
+    this.#result = null;
+    this.#generationResult = null;
   };
 
   #handleUnknownCustomPropertiesChange = (event: Event): void => {
@@ -153,14 +196,22 @@ class ValidatorController extends HTMLElement {
 
   #handleFileSelection = async (event: Event): Promise<void> => {
     const input = event.currentTarget as HTMLInputElement;
-    const [file] = Array.from(input.files ?? []);
+    const files = Array.from(input.files ?? []);
+    const [file] = files;
 
     if (!file) {
       return;
     }
 
-    this.#cssSource = await file.text();
-    this.#fileName = file.name || "pasted.css";
+    this.#fileInputs = await Promise.all(
+      files.map(async (selectedFile, index) => ({
+        path: tokenInputPath(selectedFile, index),
+        css: await selectedFile.text(),
+      })),
+    );
+    this.#cssSource = this.#fileInputs[0]?.css ?? "";
+    this.#fileName =
+      files.length === 1 ? file.name || "pasted.css" : `${files.length} CSS files selected`;
     requireCachedValue(this.#inputEditor, "input editor").value = this.#cssSource;
     requireCachedValue(this.#fileNameElement, "file name").textContent = this.#fileName;
     input.value = "";
@@ -186,26 +237,97 @@ class ValidatorController extends HTMLElement {
     this.#renderOutput();
   };
 
+  #handleModeChange = (event: Event): void => {
+    const input = event.currentTarget as HTMLInputElement;
+    const nextMode: AppMode = input.value === "generate" ? "generate" : "validate";
+
+    this.#updateDefaultExample(nextMode);
+    this.#mode = nextMode;
+    this.#renderMode();
+    this.#renderOutput();
+    this.#renderStatus();
+    this.#renderStats();
+  };
+
   #validateCss = (): void => {
-    this.#result = validateFiles(
-      [
-        {
-          path: this.#fileName || "pasted.css",
-          css: this.#cssSource,
-        },
-      ],
-      {
-        checkUnresolvedCustomProperties: this.#checkUnknownCustomProperties,
-        knownCustomPropertyInputs: this.#checkUnknownCustomProperties ? this.#tokenInputs : [],
-      },
+    this.#result = validateFiles(this.#activeInputs(), {
+      checkUnresolvedCustomProperties: this.#checkUnknownCustomProperties,
+      knownCustomPropertyInputs: this.#checkUnknownCustomProperties ? this.#tokenInputs : [],
+    });
+    this.#renderOutput();
+    this.#renderStatus();
+    this.#renderStats();
+  };
+
+  #generateCss = (): void => {
+    this.#generationResult = generatePropertyRegistrations(
+      [...this.#activeInputs(), ...this.#tokenInputs],
+      { outFile: "properties.css" },
     );
     this.#renderOutput();
     this.#renderStatus();
     this.#renderStats();
   };
 
+  #activeInputs(): ValidationInput[] {
+    return this.#fileInputs.length > 0
+      ? this.#fileInputs
+      : [
+          {
+            path: this.#fileName || "pasted.css",
+            css: this.#cssSource,
+          },
+        ];
+  }
+
+  #updateDefaultExample(nextMode: AppMode): void {
+    const nextDefault = nextMode === "validate" ? VALIDATION_DEFAULT_CSS : GENERATION_DEFAULT_CSS;
+    const currentIsDefault =
+      this.#cssSource === VALIDATION_DEFAULT_CSS || this.#cssSource === GENERATION_DEFAULT_CSS;
+
+    if (!currentIsDefault) {
+      return;
+    }
+
+    this.#cssSource = nextDefault;
+    this.#fileInputs = [];
+    this.#fileName = "pasted.css";
+    this.#result = null;
+    this.#generationResult = null;
+    requireCachedValue(this.#inputEditor, "input editor").value = this.#cssSource;
+    requireCachedValue(this.#fileNameElement, "file name").textContent = this.#fileName;
+  }
+
+  #renderMode(): void {
+    const checkUnknownCustomPropertiesInput = requireCachedValue(
+      this.#checkUnknownCustomPropertiesInput,
+      "unknown custom properties input",
+    );
+    const generateButton = requireCachedValue(this.#generateButton, "generate button");
+    const outputTitle = requireCachedValue(this.#outputTitle, "output title");
+    const tokenFileInput = requireCachedValue(this.#tokenFileInput, "token file input");
+    const validateButton = requireCachedValue(this.#validateButton, "validate button");
+
+    validateButton.hidden = this.#mode !== "validate";
+    generateButton.hidden = this.#mode !== "generate";
+    checkUnknownCustomPropertiesInput.disabled = this.#mode !== "validate";
+    tokenFileInput.disabled =
+      this.#mode === "validate" ? !this.#checkUnknownCustomProperties : false;
+    outputTitle.textContent = this.#mode === "validate" ? "Validation result" : "properties.css";
+  }
+
   #renderOutput(): void {
     const outputEditor = requireCachedValue(this.#outputEditor, "output editor");
+
+    if (this.#mode === "generate") {
+      outputEditor.language = this.#outputFormat === "json" ? "json" : "css";
+      outputEditor.value = this.#generationResult
+        ? this.#outputFormat === "json"
+          ? JSON.stringify(this.#generationResult, null, 2)
+          : this.#generationResult.css || "No ready registrations generated. Review JSON output."
+        : INITIAL_GENERATION_OUTPUT;
+      return;
+    }
 
     outputEditor.language = this.#outputFormat === "json" ? "json" : "text";
     outputEditor.value = this.#result
@@ -219,6 +341,30 @@ class ValidatorController extends HTMLElement {
     const statSkipped = requireCachedValue(this.#statSkipped, "skipped stat");
     const statValidated = requireCachedValue(this.#statValidated, "validated stat");
 
+    const statDiagnosticsLabel = requireCachedValue(
+      this.#statDiagnosticsLabel,
+      "diagnostics label",
+    );
+    const statRegisteredLabel = requireCachedValue(this.#statRegisteredLabel, "registered label");
+    const statSkippedLabel = requireCachedValue(this.#statSkippedLabel, "skipped label");
+    const statValidatedLabel = requireCachedValue(this.#statValidatedLabel, "validated label");
+
+    if (this.#mode === "generate") {
+      statDiagnosticsLabel.textContent = "Diagnostics";
+      statRegisteredLabel.textContent = "Generated";
+      statValidatedLabel.textContent = "Review";
+      statSkippedLabel.textContent = "Total";
+      statDiagnostics.textContent = String(this.#generationResult?.diagnostics.length ?? "—");
+      statRegistered.textContent = String(this.#generationResult?.generatedCount ?? "—");
+      statValidated.textContent = String(this.#generationResult?.reviewCount ?? "—");
+      statSkipped.textContent = String(this.#generationResult?.candidates.length ?? "—");
+      return;
+    }
+
+    statDiagnosticsLabel.textContent = "Diagnostics";
+    statRegisteredLabel.textContent = "Registered";
+    statValidatedLabel.textContent = "Validated";
+    statSkippedLabel.textContent = "Skipped";
     statDiagnostics.textContent = String(this.#result?.diagnostics.length ?? "—");
     statRegistered.textContent = String(this.#result?.registry.length ?? "—");
     statSkipped.textContent = String(this.#result?.skippedDeclarations ?? "—");
@@ -227,6 +373,35 @@ class ValidatorController extends HTMLElement {
 
   #renderStatus(): void {
     const validationStatus = requireCachedValue(this.#validationStatus, "validation status");
+    const generationResult = this.#generationResult;
+
+    if (this.#mode === "generate") {
+      validationStatus.replaceChildren();
+      validationStatus.hidden = !generationResult;
+
+      if (!generationResult) {
+        return;
+      }
+
+      const message = document.createElement("div");
+      const heading = document.createElement("strong");
+      const detail = document.createElement("span");
+      const feedback = document.createElement("a");
+
+      message.className = generationResult.reviewCount > 0 ? "warning-message" : "success-message";
+      message.role = "status";
+      heading.textContent =
+        generationResult.reviewCount > 0
+          ? "Review generated registrations."
+          : "Generated registrations are valid.";
+      detail.textContent = `${generationResult.generatedCount} ready, ${generationResult.reviewCount} need review. `;
+      feedback.href = FEEDBACK_URL;
+      feedback.textContent = "Share feedback on issue #98.";
+      message.append(heading, detail, feedback);
+      validationStatus.append(message);
+      return;
+    }
+
     const hasPassed = Boolean(this.#result && this.#result.diagnostics.length === 0);
     const configurationWarning = this.#configurationWarning();
 

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -184,8 +184,7 @@ class ValidatorController extends HTMLElement {
   #handleEditorChange = (event: Event): void => {
     this.#cssSource = (event as CustomEvent<string>).detail;
     this.#fileInputs = [];
-    this.#result = null;
-    this.#generationResult = null;
+    this.#resetResults();
   };
 
   #handleUnknownCustomPropertiesChange = (event: Event): void => {
@@ -214,6 +213,7 @@ class ValidatorController extends HTMLElement {
       files.length === 1 ? file.name || "pasted.css" : `${files.length} CSS files selected`;
     requireCachedValue(this.#inputEditor, "input editor").value = this.#cssSource;
     requireCachedValue(this.#fileNameElement, "file name").textContent = this.#fileName;
+    this.#resetResults();
     input.value = "";
   };
 
@@ -227,6 +227,7 @@ class ValidatorController extends HTMLElement {
         css: await file.text(),
       })),
     );
+    this.#resetResults();
     input.value = "";
   };
 
@@ -280,6 +281,14 @@ class ValidatorController extends HTMLElement {
         ];
   }
 
+  #resetResults(): void {
+    this.#result = null;
+    this.#generationResult = null;
+    this.#renderOutput();
+    this.#renderStatus();
+    this.#renderStats();
+  }
+
   #updateDefaultExample(nextMode: AppMode): void {
     const nextDefault = nextMode === "validate" ? VALIDATION_DEFAULT_CSS : GENERATION_DEFAULT_CSS;
     const currentIsDefault =
@@ -313,11 +322,20 @@ class ValidatorController extends HTMLElement {
     checkUnknownCustomPropertiesInput.disabled = this.#mode !== "validate";
     tokenFileInput.disabled =
       this.#mode === "validate" ? !this.#checkUnknownCustomProperties : false;
-    outputTitle.textContent = this.#mode === "validate" ? "Validation result" : "properties.css";
+    outputTitle.textContent = this.#outputTitleText();
+  }
+
+  #outputTitleText(): string {
+    if (this.#mode === "validate") {
+      return "Validation result";
+    }
+
+    return this.#outputFormat === "json" ? "Generation result" : "properties.css";
   }
 
   #renderOutput(): void {
     const outputEditor = requireCachedValue(this.#outputEditor, "output editor");
+    requireCachedValue(this.#outputTitle, "output title").textContent = this.#outputTitleText();
 
     if (this.#mode === "generate") {
       outputEditor.language = this.#outputFormat === "json" ? "json" : "css";

--- a/web/src/styles.css
+++ b/web/src/styles.css
@@ -631,6 +631,10 @@ h2 {
   border-color: var(--color-accent);
 }
 
+.primary-action[hidden] {
+  display: none;
+}
+
 .file-button:hover,
 .check-toggle:hover,
 .primary-action:hover {
@@ -640,7 +644,8 @@ h2 {
 .file-button:focus-within,
 .check-toggle:focus-within,
 .primary-action:focus-visible,
-.format-toggle input:focus-visible + span {
+.format-toggle input:focus-visible + span,
+.mode-toggle input:focus-visible + span {
   outline: 0.1875rem solid var(--color-focus);
   outline-offset: 0.1875rem;
 }
@@ -695,7 +700,8 @@ h2 {
   white-space: nowrap;
 }
 
-.format-toggle {
+.format-toggle,
+.mode-toggle {
   display: inline-flex;
   align-items: center;
   gap: 0.25rem;
@@ -707,7 +713,8 @@ h2 {
   border-radius: 0.375rem;
 }
 
-.format-toggle legend {
+.format-toggle legend,
+.mode-toggle legend {
   position: absolute;
   inline-size: 0.0625rem;
   block-size: 0.0625rem;
@@ -717,17 +724,20 @@ h2 {
   clip-path: inset(50%);
 }
 
-.format-toggle label {
+.format-toggle label,
+.mode-toggle label {
   display: block;
   cursor: pointer;
 }
 
-.format-toggle input {
+.format-toggle input,
+.mode-toggle input {
   position: absolute;
   opacity: 0;
 }
 
-.format-toggle span {
+.format-toggle span,
+.mode-toggle span {
   display: block;
   border-radius: 0.25rem;
   padding-block: 0.35rem;
@@ -738,7 +748,8 @@ h2 {
   letter-spacing: 0.01em;
 }
 
-.format-toggle input:checked + span {
+.format-toggle input:checked + span,
+.mode-toggle input:checked + span {
   color: var(--color-panel);
   background: var(--color-heading);
 }
@@ -882,15 +893,18 @@ h2 {
     flex-direction: column;
   }
 
-  .format-toggle {
+  .format-toggle,
+  .mode-toggle {
     inline-size: 100%;
   }
 
-  .format-toggle label {
+  .format-toggle label,
+  .mode-toggle label {
     flex: 1;
   }
 
-  .format-toggle span {
+  .format-toggle span,
+  .mode-toggle span {
     text-align: center;
   }
 

--- a/web/tests/e2e/validator.e2e.ts
+++ b/web/tests/e2e/validator.e2e.ts
@@ -52,6 +52,12 @@ test("renders the validator workspace", async ({ page }) => {
           - /url: https://github.com/schalkneethling/css-property-type-validator
       - region "Validation actions":
         - heading "Validation actions" [level=2]
+        - group "Mode":
+          - text: Mode
+          - radio "Validate" [checked]
+          - text: Validate
+          - radio "Generate"
+          - text: Generate
         - checkbox "Unknown custom properties"
         - text: Unknown custom properties Open Tokens
         - button "Open Tokens" [disabled]
@@ -88,6 +94,92 @@ test("renders the validator workspace", async ({ page }) => {
             - definition: —
   `);
   await expect(page.getByLabel("Open CSS")).toBeAttached();
+  await expect(page.getByRole("button", { name: "Validate" })).toBeVisible();
+  await expect(page.getByRole("button", { name: "Generate" })).toBeHidden();
+});
+
+test("generates property registrations from pasted CSS", async ({ page }) => {
+  await page.goto("/");
+  await page.getByLabel("Generate").check();
+  await replaceEditorContents(page, ":root { --brand-color: red; --space: 1px; }");
+  await page.getByRole("button", { name: "Generate" }).click();
+
+  await expect(page.getByRole("region", { name: "properties.css" })).toContainText(
+    "@property --brand-color",
+  );
+  await expect(page.getByRole("region", { name: "properties.css" })).toContainText(
+    "@property --space",
+  );
+  await expect(page.getByRole("status")).toContainText("Generated registrations are valid.");
+  await expect(page.getByRole("status")).toContainText("ready, 0 need review.");
+});
+
+test("switches the default example when changing modes", async ({ page }) => {
+  await page.goto("/");
+
+  await expect(page.getByRole("textbox", { name: "CSS input" })).toContainText(
+    "@property --brand-color",
+  );
+
+  await page.getByLabel("Generate").check();
+
+  await expect(page.getByRole("textbox", { name: "CSS input" })).not.toContainText(
+    "@property --brand-color",
+  );
+  await expect(page.getByRole("textbox", { name: "CSS input" })).toContainText("--space: 1px");
+
+  await page.getByLabel("Validate").check();
+
+  await expect(page.getByRole("textbox", { name: "CSS input" })).toContainText(
+    "@property --brand-color",
+  );
+});
+
+test("does not replace authored CSS when changing modes", async ({ page }) => {
+  await page.goto("/");
+  await replaceEditorContents(page, ".card { --brand-color: red; }");
+  await page.getByLabel("Generate").check();
+
+  await expect(page.getByRole("textbox", { name: "CSS input" })).toContainText(
+    "--brand-color: red",
+  );
+  await expect(page.getByRole("textbox", { name: "CSS input" })).not.toContainText("--space: 1px");
+});
+
+test("reports existing registrations in generation JSON output", async ({ page }) => {
+  await page.goto("/");
+  await page.getByLabel("Generate").check();
+  await replaceEditorContents(
+    page,
+    '@property --brand-color { syntax: "<color>"; inherits: true; initial-value: red; }\n:root { --brand-color: blue; }',
+  );
+  await page.getByRole("button", { name: "Generate" }).click();
+  await page.getByLabel("JSON").check();
+
+  await expect(page.getByText('"status": "existing"')).toBeVisible();
+});
+
+test("dedupes multiple uploaded CSS files during generation", async ({ page }) => {
+  await page.goto("/");
+  await page.getByLabel("Generate").check();
+  await page.getByLabel("Open CSS").setInputFiles([
+    {
+      name: "tokens.css",
+      mimeType: "text/css",
+      buffer: Buffer.from(":root { --space: 1px; }\n"),
+    },
+    {
+      name: "component.css",
+      mimeType: "text/css",
+      buffer: Buffer.from(".card { --space: 1px; }\n"),
+    },
+  ]);
+  await page.getByRole("button", { name: "Generate" }).click();
+  await page.getByLabel("JSON").check();
+
+  await expect(page.getByText('"generatedCount": 1')).toBeVisible();
+  await expect(page.getByText('"tokens.css"').first()).toBeVisible();
+  await expect(page.getByText('"component.css"').first()).toBeVisible();
 });
 
 test("shows a human diagnostic for pasted invalid CSS", async ({ page }) => {


### PR DESCRIPTION
## Summary
- add an experimental `generate` command to infer `@property` rules from authored custom property declarations
- expose generation APIs from the core package and wire them into the web UI with mode switching
- update docs, styles, and tests for the new generation flow

## Testing
- unit tests for generation and existing CLI validation behavior
- Playwright e2e coverage for generation mode, mode switching, and validation flows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental generate mode/command to infer conservative `@property` registrations from existing CSS (CLI + web UI) and mode selector in the UI.

* **Documentation**
  * Added CLI/core README guidance and a draft write-up describing generation usage, options, and limitations.

* **Tests**
  * Added/expanded unit, integration, and E2E tests covering generation behavior and CLI outputs.

* **Chores**
  * Bumped TypeScript target and UI styling adjustments for mode controls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->