### PR TITLE
Add staged Bumpy release automation

### DIFF
--- a/.bumpy/_config.json
+++ b/.bumpy/_config.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "../node_modules/@varlock/bumpy/config-schema.json",
+  "baseBranch": "main",
+  "access": "public",
+  "changelog": "./.bumpy/changelog-formatter.mjs",
+  "include": [
+    "@schalkneethling/css-property-type-validator-core",
+    "@schalkneethling/css-property-type-validator-cli"
+  ],
+  "ignore": [
+    "css-property-type-validator",
+    "@schalkneethling/css-property-type-validator-web",
+    "@schalkneethling/stylelint-plugin-css-property-type-validator"
+  ],
+  "updateInternalDependencies": "patch",
+  "dependencyBumpRules": {
+    "dependencies": {
+      "trigger": "patch",
+      "bumpAs": "patch"
+    },
+    "peerDependencies": false,
+    "devDependencies": false,
+    "optionalDependencies": false
+  },
+  "packages": {
+    "@schalkneethling/css-property-type-validator-core": {
+      "managed": true
+    },
+    "@schalkneethling/css-property-type-validator-cli": {
+      "managed": true
+    },
+    "@schalkneethling/stylelint-plugin-css-property-type-validator": {
+      "managed": false
+    },
+    "css-property-type-validator": {
+      "managed": false
+    }
+  },
+  "publish": {
+    "packManager": "pnpm",
+    "publishManager": "pnpm",
+    "protocolResolution": "pack"
+  },
+  "gitUser": {
+    "name": "bumpy-bot",
+    "email": "276066384+bumpy-bot@users.noreply.github.com"
+  },
+  "versionPr": {
+    "title": "Version packages",
+    "branch": "bumpy/version-packages",
+    "preamble": "This PR was created by Bumpy from committed bump files in `.bumpy/`. Review the generated versions and changelogs, then merge when ready to prepare the manual trusted-publishing GitHub Release."
+  }
+}

--- a/.bumpy/changelog-formatter.mjs
+++ b/.bumpy/changelog-formatter.mjs
@@ -1,0 +1,96 @@
+const BUMP_HEADINGS = {
+  major: "Breaking Changes",
+  minor: "Features",
+  patch: "Bug Fixes",
+};
+
+const BUMP_ORDER = ["major", "minor", "patch"];
+
+function bumpTypeForPackage(bumpFile, packageName) {
+  const release = bumpFile.releases.find(({ name }) => name === packageName);
+  return release?.type === "none" || !release?.type ? "patch" : release.type;
+}
+
+function sortBumpFiles(bumpFiles, packageName) {
+  return [...bumpFiles].sort((a, b) => {
+    return (
+      BUMP_ORDER.indexOf(bumpTypeForPackage(b, packageName)) -
+      BUMP_ORDER.indexOf(bumpTypeForPackage(a, packageName))
+    );
+  });
+}
+
+function formatSummary(summary) {
+  return summary
+    .trim()
+    .split("\n")
+    .map((line) => line.trim())
+    .filter(Boolean);
+}
+
+function dependencySourceList(release) {
+  if (!release.bumpSources.length) {
+    return "(internal)";
+  }
+
+  return release.bumpSources.map(({ name, newVersion }) => `\`${name}\` v${newVersion}`).join(", ");
+}
+
+export default function changelogFormatter() {
+  return ({ release, bumpFiles, date }) => {
+    const lines = [`## ${release.newVersion} (${date})`, ""];
+    const grouped = new Map(BUMP_ORDER.map((type) => [type, []]));
+    const releaseBumpFiles = sortBumpFiles(
+      bumpFiles.filter(({ id }) => release.bumpFiles.includes(id)),
+      release.name,
+    );
+
+    for (const bumpFile of releaseBumpFiles) {
+      const type = bumpTypeForPackage(bumpFile, release.name);
+      const summaryLines = formatSummary(bumpFile.summary ?? "");
+
+      if (!summaryLines.length) {
+        continue;
+      }
+
+      grouped.get(type)?.push(summaryLines);
+    }
+
+    if (release.isDependencyBump) {
+      grouped.get("patch")?.push([`Updated dependency ${dependencySourceList(release)}.`]);
+    }
+
+    if (release.isGroupBump && !release.isDependencyBump) {
+      grouped
+        .get(release.type)
+        ?.push([`Version bump from group with ${dependencySourceList(release)}.`]);
+    }
+
+    if (release.isCascadeBump && !release.isDependencyBump && !release.isGroupBump) {
+      grouped.get(release.type)?.push([`Version bump from ${dependencySourceList(release)}.`]);
+    }
+
+    for (const type of BUMP_ORDER) {
+      const entries = grouped.get(type);
+
+      if (!entries?.length) {
+        continue;
+      }
+
+      lines.push(`### ${BUMP_HEADINGS[type]}`, "");
+
+      for (const entry of entries) {
+        const [firstLine, ...rest] = entry;
+        lines.push(`- ${firstLine}`);
+
+        for (const line of rest) {
+          lines.push(`  ${line}`);
+        }
+      }
+
+      lines.push("");
+    }
+
+    return lines.join("\n");
+  };
+}

--- a/.github/workflows/bumpy-check.yml
+++ b/.github/workflows/bumpy-check.yml
@@ -1,0 +1,40 @@
+name: Bumpy Check
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  check:
+    name: Check release intent
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Check release intent
+        run: pnpm exec bumpy ci check --strict
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Check changelog format
+        run: pnpm run release:check-changelogs

--- a/.github/workflows/bumpy-version-pr.yml
+++ b/.github/workflows/bumpy-version-pr.yml
@@ -1,0 +1,63 @@
+name: Bumpy Version PR
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: bumpy-version-pr
+  cancel-in-progress: false
+
+jobs:
+  version-pr:
+    name: Create or update version PR
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          persist-credentials: true
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@0e279bb959325dab635dd2c09392533439d90093 # v6.0.8
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version-file: .nvmrc
+          package-manager-cache: false
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --ignore-scripts
+
+      - name: Detect pending bump files
+        id: bump-files
+        run: |
+          # $GITHUB_OUTPUT is a GitHub Actions-provided file used to expose step outputs.
+          if find .bumpy -maxdepth 1 -type f -name '*.md' ! -name README.md -print -quit | grep -q .; then
+            echo "present=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "present=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Plan Bumpy release
+        id: plan
+        if: steps.bump-files.outputs.present == 'true'
+        run: pnpm exec bumpy ci plan
+
+      - name: Create or update version PR
+        if: steps.plan.outputs.mode == 'version-pr'
+        run: pnpm exec bumpy ci release
+        env:
+          GH_TOKEN: ${{ github.token }}
+
+      - name: Skip publishing during staged migration
+        if: steps.bump-files.outputs.present != 'true' || steps.plan.outputs.mode != 'version-pr'
+        run: echo "No version PR needed; staged migration never runs Bumpy publish mode."

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -19,7 +19,7 @@ The CI workflow runs on pull requests and pushes to `main` and verifies:
 - `@schalkneethling/css-property-type-validator-cli`
 - `@schalkneethling/stylelint-plugin-css-property-type-validator`
 
-Bumpy currently manages core and CLI only. The Stylelint plugin remains manual while it is on prerelease versions because Bumpy supports `major`, `minor`, and `patch` bumps, and a patch bump from `0.1.0-beta.x` would graduate it to `0.1.0`. Add it to Bumpy once it is ready for stable releases. The VS Code extension is not managed by Bumpy yet. Keep versioning and packaging both manual packages by hand.
+Bumpy currently manages core and CLI only. The Stylelint plugin remains manual while it is on prerelease versions because Bumpy supports `major`, `minor`, and `patch` bumps, and a patch bump from `0.1.0-beta.x` would graduate it to `0.1.0`. Add it to Bumpy once it is ready for stable releases. The VS Code extension is not managed by Bumpy yet. Keep versioning and packaging the Stylelint plugin and VS Code extension manually.
 
 ## Trusted Publishing Setup
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-This repository publishes npm packages from manually published GitHub Releases. The publish workflow uses npm trusted publishing with GitHub OIDC, so no `NPM_TOKEN` repository secret is required.
+This repository uses Bumpy to collect release intent, create package version PRs, and generate changelogs for stable npm packages. Publishing still happens from manually published GitHub Releases during the staged Bumpy migration. The publish workflow uses npm trusted publishing with GitHub OIDC, so no `NPM_TOKEN` repository secret is required.
 
 ## CI
 
@@ -19,6 +19,8 @@ The CI workflow runs on pull requests and pushes to `main` and verifies:
 - `@schalkneethling/css-property-type-validator-cli`
 - `@schalkneethling/stylelint-plugin-css-property-type-validator`
 
+Bumpy currently manages core and CLI only. The Stylelint plugin remains manual while it is on prerelease versions because Bumpy supports `major`, `minor`, and `patch` bumps, and a patch bump from `0.1.0-beta.x` would graduate it to `0.1.0`. Add it to Bumpy once it is ready for stable releases. The VS Code extension is not managed by Bumpy yet. Keep versioning and packaging both manual packages by hand.
+
 ## Trusted Publishing Setup
 
 Each npm package must have a trusted publisher configured with:
@@ -33,12 +35,54 @@ The first publish of a brand-new package must happen manually, because npm only 
 
 ## Conventional Commits
 
-Use conventional commit style for PR titles and commits merged to `main`, even though version bumps are manual:
+Use conventional commit style for PR titles and commits merged to `main`, even though package bump intent now lives in Bumpy bump files:
 
 - `feat:` for user-facing additions
 - `fix:` for bug fixes
 - `docs:` for documentation-only changes
 - `feat!:` or `BREAKING CHANGE:` for breaking changes
+
+## Bumpy Bump Files
+
+Every PR that changes one of the Bumpy-managed npm packages should include a bump file in `.bumpy/`. Create one interactively with:
+
+```bash
+pnpm run release:add
+```
+
+For non-interactive use, pass package bumps and a message directly:
+
+```bash
+pnpm exec bumpy add --packages "@schalkneethling/css-property-type-validator-core:patch" --message "Fix import URL resolution."
+```
+
+Use `patch` for fixes, `minor` for user-facing additions, and `major` for breaking changes. Use an empty bump file only when a PR touches managed package files but should not release a package:
+
+```bash
+pnpm exec bumpy add --empty --message "No package release needed."
+```
+
+Preview the release plan with:
+
+```bash
+pnpm run release:status
+```
+
+When bump files merge to `main`, the Bumpy Version PR workflow creates or updates the `bumpy/version-packages` PR. That PR updates package versions, workspace dependency ranges, lockfile metadata, and package changelogs for managed packages. During this staged migration, merging that PR does not publish packages automatically.
+
+The workflow uses the default `github.token`; no personal access token is required for this staged setup. If you later want Bumpy-created version PRs to trigger all pull request workflows automatically, add a `BUMPY_GH_TOKEN` secret and wire it into the workflow.
+
+## Changelog Format
+
+Bumpy uses a repository-specific changelog formatter so generated entries stay compatible with the formatter/linter toolchain:
+
+- `# Changelog` stays as the file title.
+- Generated version headings use `## x.y.z (YYYY-MM-DD)`.
+- Generated sections use headings such as `### Features` and `### Bug Fixes`.
+- Generated list items use `-` bullets, not `*`.
+- Generated entries must not contain repeated blank lines.
+
+Do not hand-edit generated changelog formatting in a version PR unless `pnpm run release:check-changelogs` or `pnpm run format:check` fails.
 
 ## Release Tags
 
@@ -53,20 +97,26 @@ Use `stylelint-v0.1.0-beta.0` for the first Stylelint beta release.
 
 Packages that depend on workspace packages must only be released after their workspace dependencies have already been published at the versions that will be written into the packed package. For example, if the Stylelint plugin uses a new core export, bump and publish core first, or use an `all-vX.Y.Z` release so core is published before the plugin.
 
-## Manual Release Steps
+## Version PR Checks
 
-1. Update the target package version in its `package.json`. If the target package depends on another workspace package whose public API changed, update that dependency package version too.
-2. Update the relevant changelog or release notes.
-3. Run the local verification gate:
+Before merging a Bumpy version PR, verify:
+
+```bash
+pnpm install --frozen-lockfile --ignore-scripts
+pnpm run release:verify
+```
+
+## Manual Publish Steps
+
+1. Merge the Bumpy version PR.
+2. Run the local verification gate:
 
    ```bash
    pnpm install --frozen-lockfile --ignore-scripts
-   pnpm run check
-   pnpm run check:supported-syntax-names
-   pnpm run build
+   pnpm run release:verify
    ```
 
-4. Pack locally to inspect the tarball before release:
+3. Pack locally to inspect the tarball before release:
 
    ```bash
    mkdir -p /tmp/css-property-type-validator-pack
@@ -75,9 +125,10 @@ Packages that depend on workspace packages must only be released after their wor
    pnpm --filter @schalkneethling/stylelint-plugin-css-property-type-validator pack --pack-destination /tmp/css-property-type-validator-pack
    ```
 
-5. Merge the release-prep PR.
-6. Create and publish a GitHub Release with the matching tag prefix. Use `all-vX.Y.Z` when releasing a package together with a workspace dependency it relies on.
-7. Confirm the `Publish` workflow completes and the package appears on npm.
+4. Create and publish a GitHub Release with the matching tag prefix. Use `all-vX.Y.Z` when releasing a package together with a workspace dependency it relies on.
+5. Confirm the `Publish` workflow completes and the package appears on npm.
+
+If Bumpy is unavailable, fall back to manually updating package versions, workspace dependency versions, and changelogs in a release-prep PR before following the same publish steps.
 
 ## Security Notes
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,12 @@
     "test": "vp test run",
     "test:e2e": "pnpm --filter @schalkneethling/css-property-type-validator-web test:e2e",
     "typecheck": "tsc -b tsconfig.json",
+    "release:add": "bumpy add",
+    "release:status": "bumpy status",
+    "release:version": "bumpy version && pnpm run release:check-changelogs",
+    "release:check": "bumpy check --strict && pnpm run release:check-changelogs && pnpm run format:check",
+    "release:check-changelogs": "node scripts/check-changelog-format.mjs",
+    "release:verify": "pnpm run release:check-changelogs && pnpm run check && pnpm run check:supported-syntax-names",
     "update:vscode-data": "pnpm --filter ./packages/vscode run sync:data && pnpm run format",
     "check:supported-syntax-names": "node scripts/check-supported-syntax-names.mjs",
     "clean": "node scripts/clean.mjs",
@@ -32,6 +38,7 @@
   },
   "devDependencies": {
     "@types/node": "^25.9.1",
+    "@varlock/bumpy": "1.10.2",
     "cheerio": "^1.2.0",
     "typescript": "^6.0.3",
     "vite-plus": "^0.1.22"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@types/node':
         specifier: ^25.9.1
         version: 25.9.1
+      '@varlock/bumpy':
+        specifier: 1.10.2
+        version: 1.10.2
       cheerio:
         specifier: ^1.2.0
         version: 1.2.0
@@ -807,6 +810,10 @@ packages:
   '@typespec/ts-http-runtime@0.3.5':
     resolution: {integrity: sha512-yURCknZhvywvQItHMMmFSo+fq5arCUIyz/CVk7jD89MSai7dkaX8ufjCWp3NttLojoTVbcE72ri+be/TnEbMHw==}
     engines: {node: '>=20.0.0'}
+
+  '@varlock/bumpy@1.10.2':
+    resolution: {integrity: sha512-y590dPGSvIkrHtk+ILWzBBj8UdtNMkRCXl7qRM3lwOOeC7M3m/hTgQoATP43u/plPui76tTDCvoclwEsAAephQ==}
+    hasBin: true
 
   '@vitest/expect@4.1.7':
     resolution: {integrity: sha512-1R+tw0ortHEbZDGMymm+pN7/AFQ/RkFFdtd7EN+VBpynKmLbP8A3rpEXdshBJ7+8hQ9zBJh/i1s0yKNtxAnU7w==}
@@ -3387,6 +3394,8 @@ snapshots:
       tslib: 2.8.1
     transitivePeerDependencies:
       - supports-color
+
+  '@varlock/bumpy@1.10.2': {}
 
   '@vitest/expect@4.1.7':
     dependencies:

--- a/scripts/check-changelog-format.mjs
+++ b/scripts/check-changelog-format.mjs
@@ -1,0 +1,57 @@
+import { readFile } from "node:fs/promises";
+
+const changelogPaths = [
+  "packages/core/CHANGELOG.md",
+  "packages/cli/CHANGELOG.md",
+  "packages/stylelint/CHANGELOG.md",
+];
+
+let hasError = false;
+
+function report(path, message) {
+  hasError = true;
+  console.error(`${path}: ${message}`);
+}
+
+for (const path of changelogPaths) {
+  let content;
+
+  try {
+    content = await readFile(path, "utf8");
+  } catch {
+    continue;
+  }
+
+  if (!content.startsWith("# Changelog\n\n")) {
+    report(path, "must start with '# Changelog' followed by one blank line.");
+  }
+
+  const lines = content.split("\n");
+
+  let insideBumpyEntry = false;
+
+  for (let index = 0; index < lines.length; index++) {
+    const line = lines[index];
+    const lineNumber = index + 1;
+
+    if (line.startsWith("## ")) {
+      insideBumpyEntry = /^## \d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)? \(\d{4}-\d{2}-\d{2}\)$/.test(line);
+    }
+
+    if (!insideBumpyEntry) {
+      continue;
+    }
+
+    if (line.startsWith("* ")) {
+      report(path, `line ${lineNumber} uses '*' bullet; use '-' bullets.`);
+    }
+
+    if (line === "" && lines[index + 1] === "" && lines[index + 2] === "") {
+      report(path, `line ${lineNumber} has more than one blank line.`);
+    }
+  }
+}
+
+if (hasError) {
+  process.exit(1);
+}

--- a/scripts/check-changelog-format.mjs
+++ b/scripts/check-changelog-format.mjs
@@ -18,8 +18,12 @@ for (const path of changelogPaths) {
 
   try {
     content = await readFile(path, "utf8");
-  } catch {
-    continue;
+  } catch (error) {
+    if (error.code === "ENOENT") {
+      continue;
+    }
+
+    throw error;
   }
 
   if (!content.startsWith("# Changelog\n\n")) {
@@ -46,7 +50,7 @@ for (const path of changelogPaths) {
       report(path, `line ${lineNumber} uses '*' bullet; use '-' bullets.`);
     }
 
-    if (line === "" && lines[index + 1] === "" && lines[index + 2] === "") {
+    if (index + 1 < lines.length && line === "" && lines[index + 1] === "") {
       report(path, `line ${lineNumber} has more than one blank line.`);
     }
   }


### PR DESCRIPTION
## Summary
- Add Bumpy configuration and release scripts for npm package versioning and changelog generation.
- Add PR and main-branch workflows to create version PRs while keeping publishing manual during the staged migration.
- Document the new bump-file flow and changelog formatting rules in `RELEASING.md`.

## Testing
- `pnpm run release:check-changelogs`
- `pnpm run format:check`
- `pnpm exec bumpy check --no-fail`
- `pnpm run check`
- `pnpm run check:supported-syntax-names`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated release process with staged Bumpy migration, new version-PR checks, changelog rules, and manual publish verification steps.

* **New Features**
  * Added automated changelog formatting and conditional version PR creation on main branch changes.

* **Chores**
  * Added release-related npm scripts and CI checks to validate bumps and changelog formatting before publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->