### PR TITLE
Fold determinant review fixes back into the guardrail scripts

### DIFF
--- a/docs/acceptance/repository-guardrails.md
+++ b/docs/acceptance/repository-guardrails.md
@@ -6,12 +6,14 @@ static: they do not claim browser behavior or replace specification-backed seman
 ## AC-GUARD-001 — Traceability is complete before handoff
 
 - **In scope:** Each acceptance document has unique stable `AC-*` headings and a traceability
-  table that names every heading.
+  table that names every heading exactly once and names no criterion that is not declared as a
+  heading in the same document.
 - **Out of scope:** Deciding whether a criterion is sufficient, or parsing arbitrary Markdown
   table dialects.
 - **Preconditions:** An implementation slice records its boundaries in `docs/acceptance/`.
-- **Observable result:** `check-acceptance-traceability` rejects an orphan, duplicate, or
-  undocumented criterion before handoff.
+- **Observable result:** `check-acceptance-traceability` rejects an orphan, duplicate,
+  undocumented, or table-only stale criterion before handoff; the traceability table is
+  isolated up to the next heading so surrounding prose cannot satisfy the count.
 - **Uncertainty:** A malformed or missing table fails closed and asks for human repair.
 - **Provenance:** Product decision: acceptance-driven RED/GREEN workflow.
 - **Outcome:** Gating contributor contract.
@@ -76,10 +78,13 @@ static: they do not claim browser behavior or replace specification-backed seman
   separate commands and retain their distinct failure causes.
 - **Out of scope:** Automatically approving acceptance criteria, closing issues, or substituting
   a human overreach review.
-- **Preconditions:** The contributor supplies a stable criterion ID and, for RED, an explicit
-  test command.
+- **Preconditions:** The contributor supplies a stable criterion ID that is declared as a
+  heading in `docs/acceptance/` and, for RED, an explicit test command.
 - **Observable result:** Lifecycle scripts validate guardrails before executing the requested
-  verification and reject missing criterion/test inputs with usage exit status 2.
+  verification and reject missing criterion/test inputs — and criteria not declared in
+  `docs/acceptance/` — with usage exit status 2. Only a numeric nonzero exit is accepted as RED
+  evidence: a RED command that passes or is terminated by a signal is rejected, and a
+  signal-terminated guardrail or verification child is a failure, never a success.
 - **Uncertainty:** A passing automation result does not make an advisory or uncertain diagnostic
   gating.
 - **Provenance:** Product decision: acceptance-driven RED/GREEN workflow.
@@ -100,17 +105,36 @@ static: they do not claim browser behavior or replace specification-backed seman
   CodeQL alert from PR #172 review 4891253884.
 - **Outcome:** Gating repository security contract.
 
+## AC-GUARD-008 — Guardrail sources use deterministic patterns
+
+- **In scope:** Guardrail and lifecycle scripts under `scripts/` contain no locale-sensitive
+  sort comparisons (`localeCompare`) and no unbounded fetch-response buffering (`.text()`,
+  `.json()`, or `.arrayBuffer()` on a response, or inline on `await fetch(...)`), enforced by
+  structural ast-grep rules with a pinned CLI version.
+- **Out of scope:** Product package sources (their output ordering is a separate contract
+  decision), semantic proof that a streamed read is correctly bounded, and receivers the
+  naming-convention rule cannot see.
+- **Preconditions:** `@ast-grep/cli` is installed as an exact-version dev dependency.
+- **Observable result:** `check-determinism-rules` reports each violating file, line, and rule
+  and fails; a clean tree passes with an explicit confirmation.
+- **Uncertainty:** Structural matching is syntactic; findings are reviewed rather than
+  auto-fixed, and the response rule depends on `response`/`res`/`resp` receiver naming.
+- **Provenance:** Determinant PR #3 review: both patterns recurred in code distilled from this
+  repository.
+- **Outcome:** Gating guardrail-quality contract.
+
 ## Contract table
 
-| Contract            | Required observable behavior                                                                                |
-| ------------------- | ----------------------------------------------------------------------------------------------------------- |
-| Traceability        | Every `AC-*` heading appears once in the document's traceability table and nowhere else as a heading        |
-| Core boundary       | Core has no Node-only or project-context imports and does not depend on `process`                           |
-| Bounded reads       | Direct production `readFile`, `readFileSync`, and `createReadStream` calls occur only in the bounded reader |
-| Diagnostic registry | Activated registry codes are unique, match `CPTV_*`, and cover all static uses                              |
-| Generated registry  | Activated manifest digests match bytes and lists all `@generated` source files                              |
-| Lifecycle           | RED requires one valid criterion and an explicit verification command                                       |
-| Workflow token      | Every workflow declares top-level permissions; CI grants only `contents: read`                              |
+| Contract            | Required observable behavior                                                                                            |
+| ------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| Traceability        | Every `AC-*` heading appears once in the document's traceability table, and every table criterion is a declared heading |
+| Core boundary       | Core has no Node-only or project-context imports and does not depend on `process`                                       |
+| Bounded reads       | Direct production `readFile`, `readFileSync`, and `createReadStream` calls occur only in the bounded reader             |
+| Diagnostic registry | Activated registry codes are unique, match `CPTV_*`, and cover all static uses                                          |
+| Generated registry  | Activated manifest digests match bytes and lists all `@generated` source files                                          |
+| Lifecycle           | RED requires one declared criterion and an explicit command that fails with a numeric nonzero exit                      |
+| Workflow token      | Every workflow declares top-level permissions; CI grants only `contents: read`                                          |
+| Determinism rules   | Guardrail scripts contain no locale-sensitive sorts and no unbounded fetch-response buffering                           |
 
 ## Traceability
 
@@ -123,3 +147,4 @@ static: they do not claim browser behavior or replace specification-backed seman
 | AC-GUARD-005       | `scripts/test/guardrails.test.mjs` stale generated fixture    | `scripts/check-generated-contracts.mjs`      | This document                        |
 | AC-GUARD-006       | `scripts/test/guardrails.test.mjs` lifecycle usage fixture    | `scripts/agent-verify-red.mjs`               | This document                        |
 | AC-GUARD-007       | `scripts/test/workflow-permissions.test.mjs`                  | Workflow-level permission declarations       | This document; PR #172 CodeQL review |
+| AC-GUARD-008       | `scripts/test/guardrails.test.mjs` determinism-rule fixtures  | `scripts/check-determinism-rules.mjs`        | This document; determinant PR #3     |

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "scripts": {
     "build": "pnpm -r --if-present run build",
     "check": "vp check && pnpm run typecheck && pnpm test && pnpm run build && pnpm run check:contracts",
-    "check:contracts": "pnpm run acceptance:check && pnpm run spec:check && pnpm run guardrails:core && pnpm run guardrails:reads && pnpm run guardrails:diagnostics && pnpm run guardrails:generated && pnpm run guardrails:release-order && pnpm run guardrails:versions && pnpm run ephemeral:contract:check && pnpm run ephemeral:contract:generated-check && pnpm run web:assert-release-boundary",
+    "check:contracts": "pnpm run acceptance:check && pnpm run spec:check && pnpm run guardrails:core && pnpm run guardrails:reads && pnpm run guardrails:diagnostics && pnpm run guardrails:generated && pnpm run guardrails:release-order && pnpm run guardrails:versions && pnpm run guardrails:determinism && pnpm run ephemeral:contract:check && pnpm run ephemeral:contract:generated-check && pnpm run web:assert-release-boundary",
     "format": "vp check --fix",
     "format:check": "vp check --no-lint",
     "lint": "vp check --no-fmt",
@@ -67,9 +67,11 @@
     "release:verify": "pnpm run release:check-changelogs && pnpm run check && pnpm run check:supported-syntax-names",
     "check:supported-syntax-names": "node scripts/check-supported-syntax-names.mjs",
     "clean": "node scripts/clean.mjs",
-    "example": "pnpm run build && node packages/cli/dist/cli.js fixtures/imports/main.css"
+    "example": "pnpm run build && node packages/cli/dist/cli.js fixtures/imports/main.css",
+    "guardrails:determinism": "node scripts/check-determinism-rules.mjs scripts"
   },
   "devDependencies": {
+    "@ast-grep/cli": "0.45.3",
     "@playwright/test": "1.62.1",
     "@types/node": "^26.1.2",
     "@varlock/bumpy": "1.18.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@ast-grep/cli':
+        specifier: 0.45.3
+        version: 0.45.3
       '@playwright/test':
         specifier: 1.62.1
         version: 1.62.1
@@ -131,6 +134,55 @@ importers:
         version: 8.2.1(@types/node@26.1.2)
 
 packages:
+
+  '@ast-grep/cli-darwin-arm64@0.45.3':
+    resolution: {integrity: sha512-6RZg4gRMJcSJtEJuaW5z33qfwXD7kRDGZ0T0dTxVxsLSw5BkeAjR8REysxUwPWZn+oOkzPyZ3y7/qNnSI/diIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@ast-grep/cli-darwin-x64@0.45.3':
+    resolution: {integrity: sha512-4z6ZknTMSlTirQuJ4xihXoLfG7YwAOxFCqkKuGAxAiP+K70zivib8R19vUoFJDy4s+rjyGNDdrm45/ClC5tITQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@ast-grep/cli-linux-arm64-gnu@0.45.3':
+    resolution: {integrity: sha512-T/N+Fl/pMqNjuyPV9PbTSR2bTlZrLKiCyHzJax6QNaOOVviXjEscROrAc6c0lFfc+Z07gW7Rt3oZKZdLEExutQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-linux-x64-gnu@0.45.3':
+    resolution: {integrity: sha512-HbxIy6tZa8zn4J2hG8KVIo9n4+INAgVB8l2DyHqYxGKxnod8u2B4hfTGxbMm+BjBvYxKW4oGLZtYqInMyxidyQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@ast-grep/cli-win32-arm64-msvc@0.45.3':
+    resolution: {integrity: sha512-X0+81Mgr8zsH6hu4Pqdr5h1IyAFUWbKS1PMkKT6awYiiTo/1uhVM/6WzJ+ohOQPmMTyt4poyyg46u2E4WzKECg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@ast-grep/cli-win32-ia32-msvc@0.45.3':
+    resolution: {integrity: sha512-W4H27lU/xzzIOvRo4vDTjzq91PioLCjupR7jLmLVkAqAkX2YiNRixf8NjMcQgzAgr33jUsMlyutiTElLgi1O9g==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@ast-grep/cli-win32-x64-msvc@0.45.3':
+    resolution: {integrity: sha512-UZrpVbjLQqQIRxWqeMcwyLSIhlDZyhYb8SinssM38Oo6mEB2jMfHCEoigay9UOZTfUR268n72BBV48nW2h+QwA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@ast-grep/cli@0.45.3':
+    resolution: {integrity: sha512-Cm07SHb8Q8dJfAQhrPOveAGuuzznmf6IjQa2+0Yvjt8Qfo+XIVbEIo0Prng+UDVMlaCS/FkF2eA8M3F6z4+0Wg==}
+    engines: {node: '>= 12.0.0'}
+    hasBin: true
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -1824,6 +1876,39 @@ packages:
     resolution: {integrity: sha512-OWBfhrpgK9+/4+IXG9oT8Bao4AhViQA7vdyNNH7EUg8dQYgwa70XtIBWTpCEme1P1ECyoDNYkn0wT63f8XRcVA==}
 
 snapshots:
+
+  '@ast-grep/cli-darwin-arm64@0.45.3':
+    optional: true
+
+  '@ast-grep/cli-darwin-x64@0.45.3':
+    optional: true
+
+  '@ast-grep/cli-linux-arm64-gnu@0.45.3':
+    optional: true
+
+  '@ast-grep/cli-linux-x64-gnu@0.45.3':
+    optional: true
+
+  '@ast-grep/cli-win32-arm64-msvc@0.45.3':
+    optional: true
+
+  '@ast-grep/cli-win32-ia32-msvc@0.45.3':
+    optional: true
+
+  '@ast-grep/cli-win32-x64-msvc@0.45.3':
+    optional: true
+
+  '@ast-grep/cli@0.45.3':
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      '@ast-grep/cli-darwin-arm64': 0.45.3
+      '@ast-grep/cli-darwin-x64': 0.45.3
+      '@ast-grep/cli-linux-arm64-gnu': 0.45.3
+      '@ast-grep/cli-linux-x64-gnu': 0.45.3
+      '@ast-grep/cli-win32-arm64-msvc': 0.45.3
+      '@ast-grep/cli-win32-ia32-msvc': 0.45.3
+      '@ast-grep/cli-win32-x64-msvc': 0.45.3
 
   '@babel/code-frame@7.29.0':
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - "packages/*"
   - "web"
+
+allowBuilds:
+  "@ast-grep/cli": false

--- a/scripts/agent-verify-red.mjs
+++ b/scripts/agent-verify-red.mjs
@@ -1,4 +1,19 @@
+import { resolve } from "node:path";
+
 import { runExpectedFailure, runGuardrails, usage } from "./lib/agent-lifecycle.mjs";
+import { listFiles, readTextBounded } from "./lib/guardrail-utils.mjs";
+
+async function criterionIsDeclared(criterion) {
+  const acceptanceDirectory = resolve(process.cwd(), "docs/acceptance");
+  const files = await listFiles(acceptanceDirectory, (filePath) => filePath.endsWith(".md"));
+  const headingPattern = new RegExp(`^##\\s+${criterion}\\b`, "m");
+  for (const filePath of files) {
+    if (headingPattern.test(await readTextBounded(filePath))) {
+      return true;
+    }
+  }
+  return false;
+}
 
 const args = process.argv.slice(2);
 const criterionIndex = args.indexOf("--criterion");
@@ -9,6 +24,10 @@ if (!criterion || !/^AC-[A-Z0-9]+-\d+$/.test(criterion)) {
   usage("Usage: agent-verify-red --criterion AC-AREA-001 -- <test command> [arguments]");
 } else if (separatorIndex === -1 || separatorIndex === args.length - 1) {
   usage("RED verification requires one explicit test command after --.");
+} else if (!(await criterionIsDeclared(criterion))) {
+  usage(
+    `Criterion ${criterion} is not declared as a heading in docs/acceptance/*.md; RED evidence must trace to a declared criterion.`,
+  );
 } else if (runGuardrails()) {
   const [command, ...commandArgs] = args.slice(separatorIndex + 1);
   if (runExpectedFailure(command, commandArgs)) {

--- a/scripts/check-acceptance-traceability.mjs
+++ b/scripts/check-acceptance-traceability.mjs
@@ -27,7 +27,11 @@ for (const filePath of files) {
     continue;
   }
 
-  const traceability = text.slice(traceabilityStart);
+  const afterHeading = text.slice(traceabilityStart);
+  const firstLineBreak = afterHeading.indexOf("\n");
+  const sectionBody = firstLineBreak === -1 ? "" : afterHeading.slice(firstLineBreak + 1);
+  const nextHeading = sectionBody.search(/^##\s+/m);
+  const traceability = nextHeading === -1 ? sectionBody : sectionBody.slice(0, nextHeading);
   if (
     !/^\|\s*(Criterion|Criterion\/scenario)/im.test(traceability) ||
     !/\|\s*Implementation\s*\|/im.test(traceability)
@@ -37,6 +41,7 @@ for (const filePath of files) {
     );
   }
 
+  const declared = new Set(ids);
   for (const id of ids) {
     if (headings.has(id)) {
       errors.push(
@@ -50,6 +55,17 @@ for (const filePath of files) {
     if (occurrences !== 1) {
       errors.push(
         `${filePath}: ${id} must occur exactly once in its Traceability table (found ${occurrences}).`,
+      );
+    }
+  }
+
+  const tableIds = new Set(
+    [...traceability.matchAll(/\bAC-[A-Z0-9]+-\d+\b/g)].map((match) => match[0]),
+  );
+  for (const id of tableIds) {
+    if (!declared.has(id)) {
+      errors.push(
+        `${filePath}: Traceability table references undeclared criterion ${id}; remove the stale row or declare the criterion.`,
       );
     }
   }

--- a/scripts/check-determinism-rules.mjs
+++ b/scripts/check-determinism-rules.mjs
@@ -1,0 +1,39 @@
+import { spawnSync } from "node:child_process";
+import { resolve } from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const scriptsDirectory = fileURLToPath(new URL(".", import.meta.url));
+const repositoryRoot = resolve(scriptsDirectory, "..");
+const configPath = resolve(scriptsDirectory, "determinism-rules/sgconfig.yml");
+const astGrepBinary = resolve(repositoryRoot, "node_modules/.bin/ast-grep");
+
+const targets = process.argv.slice(2);
+if (targets.length === 0) {
+  process.stderr.write("Usage: check-determinism-rules.mjs <path> [path ...]\n");
+  process.exitCode = 2;
+} else {
+  const scan = spawnSync(
+    astGrepBinary,
+    ["scan", "--config", configPath, "--json=compact", ...targets],
+    { encoding: "utf8", maxBuffer: 64 * 1024 * 1024 },
+  );
+  if (scan.error) {
+    throw scan.error;
+  }
+  if (typeof scan.status !== "number" || (scan.status !== 0 && !scan.stdout.trim())) {
+    throw new Error(`ast-grep scan failed: ${scan.stderr}`);
+  }
+
+  const findings = JSON.parse(scan.stdout);
+  if (findings.length > 0) {
+    for (const finding of findings) {
+      process.stderr.write(
+        `${finding.file}:${finding.range.start.line + 1} [${finding.ruleId}] ${finding.message}\n`,
+      );
+    }
+    process.exitCode = 1;
+  } else {
+    process.stdout.write(`Determinism rules passed for ${targets.join(", ")}.\n`);
+  }
+}

--- a/scripts/check-ephemeral-drift.mjs
+++ b/scripts/check-ephemeral-drift.mjs
@@ -1,6 +1,10 @@
 import { readFile, lstat } from "node:fs/promises";
 import process from "node:process";
 
+import { readBodyBounded } from "./lib/guardrail-utils.mjs";
+
+const MAX_API_RESPONSE_BYTES = 1024 * 1024;
+
 const manifestUrl = new URL("../compatibility/ephemeral-pages.json", import.meta.url);
 const stat = await lstat(manifestUrl);
 if (!stat.isFile() || stat.size > 64 * 1024)
@@ -23,7 +27,10 @@ const proposedCommitResponse = await fetch(
 );
 if (!proposedCommitResponse.ok)
   throw new Error(`Unable to resolve Ephemeral main: ${proposedCommitResponse.status}`);
-const proposedCommit = (await proposedCommitResponse.json()).sha;
+const proposedCommitBody = await readBodyBounded(proposedCommitResponse, MAX_API_RESPONSE_BYTES);
+if (proposedCommitBody === null)
+  throw new Error("Ephemeral commit response exceeded its 1 MiB limit.");
+const proposedCommit = JSON.parse(proposedCommitBody).sha;
 
 for (const source of contract.upstream.sources) {
   const endpoint = `https://api.github.com/repos/${owner}/${repo}/contents/${source.path}?ref=${proposedCommit}`;
@@ -32,7 +39,12 @@ for (const source of contract.upstream.sources) {
     failures.push(`${source.path}: registry response ${response.status}`);
     continue;
   }
-  const metadata = await response.json();
+  const metadataBody = await readBodyBounded(response, MAX_API_RESPONSE_BYTES);
+  if (metadataBody === null) {
+    failures.push(`${source.path}: registry response exceeded its 1 MiB limit`);
+    continue;
+  }
+  const metadata = JSON.parse(metadataBody);
   proposal.push({ path: source.path, blobSha: metadata.sha });
   if (metadata.sha !== source.blobSha)
     failures.push(`${source.path}: pinned ${source.blobSha}, main ${metadata.sha}`);

--- a/scripts/check-spec-drift.mjs
+++ b/scripts/check-spec-drift.mjs
@@ -1,5 +1,7 @@
 import process from "node:process";
 
+import { readBodyBounded } from "./lib/guardrail-utils.mjs";
+
 const approvedPublication = "26 March 2024";
 const approvedSnapshot = "https://www.w3.org/TR/2024/WD-css-properties-values-api-1-20240326/";
 const response = await fetch("https://www.w3.org/TR/css-properties-values-api-1/", {
@@ -7,9 +9,8 @@ const response = await fetch("https://www.w3.org/TR/css-properties-values-api-1/
 });
 if (!response.ok)
   throw new Error(`Unable to inspect the official specification: ${response.status}`);
-const text = await response.text();
-if (Buffer.byteLength(text) > 8 * 1024 * 1024)
-  throw new Error("Official specification response exceeded 8 MiB.");
+const text = await readBodyBounded(response, 8 * 1024 * 1024);
+if (text === null) throw new Error("Official specification response exceeded 8 MiB.");
 if (!text.includes(approvedPublication) && !text.includes(approvedSnapshot)) {
   console.error(
     `The latest published specification no longer identifies the approved ${approvedPublication} profile. Review drift; do not update semantics automatically.`,

--- a/scripts/check-spec-links.mjs
+++ b/scripts/check-spec-links.mjs
@@ -1,6 +1,8 @@
 import { lstat, readFile } from "node:fs/promises";
 import process from "node:process";
 
+import { readBodyBounded } from "./lib/guardrail-utils.mjs";
+
 const sourceUrl = new URL("../packages/core/src/specification.ts", import.meta.url);
 const stat = await lstat(sourceUrl);
 if (!stat.isFile() || stat.size > 256 * 1024)
@@ -30,8 +32,8 @@ for (const [page, fragments] of pages) {
     failures.push(`${page}: ${response.status}`);
     continue;
   }
-  const text = await response.text();
-  if (Buffer.byteLength(text) > 8 * 1024 * 1024) {
+  const text = await readBodyBounded(response, 8 * 1024 * 1024);
+  if (text === null) {
     failures.push(`${page}: response exceeded 8 MiB`);
     continue;
   }

--- a/scripts/check-supported-syntax-names.mjs
+++ b/scripts/check-supported-syntax-names.mjs
@@ -1,6 +1,7 @@
 import * as cheerio from "cheerio";
 
 import { SUPPORTED_SYNTAX_COMPONENT_NAMES } from "../packages/core/src/supported-syntax.ts";
+import { readBodyBounded } from "./lib/guardrail-utils.mjs";
 
 const SPEC_URL = "https://www.w3.org/TR/css-properties-values-api-1/#supported-names";
 
@@ -48,7 +49,10 @@ async function main() {
     throw new Error(`Failed to download the supported-names section: ${response.status}`);
   }
 
-  const documentText = await response.text();
+  const documentText = await readBodyBounded(response, 8 * 1024 * 1024);
+  if (documentText === null) {
+    throw new Error("Supported-names section response exceeded 8 MiB.");
+  }
   const specNames = extractSupportedNames(documentText).sort();
   const localNames = [...SUPPORTED_SYNTAX_COMPONENT_NAMES].sort();
 

--- a/scripts/determinism-rules/rules/no-locale-sensitive-sort.yml
+++ b/scripts/determinism-rules/rules/no-locale-sensitive-sort.yml
@@ -1,0 +1,7 @@
+id: no-locale-sensitive-sort
+language: javascript
+severity: error
+message: localeCompare ordering varies with the host locale and ICU data; use a plain code-unit comparison for deterministic ordering.
+note: "Replace with: (left < right ? -1 : left > right ? 1 : 0)."
+rule:
+  pattern: $A.localeCompare($$$ARGS)

--- a/scripts/determinism-rules/rules/no-unbounded-inline-fetch-read.yml
+++ b/scripts/determinism-rules/rules/no-unbounded-inline-fetch-read.yml
@@ -1,0 +1,10 @@
+id: no-unbounded-inline-fetch-read
+language: javascript
+severity: error
+message: Buffering a whole fetch response before checking its size makes the limit advisory; read the body in chunks and cancel once the limit is exceeded.
+note: Stream response.body with a reader, track byte length as chunks arrive, and cancel over-limit streams.
+rule:
+  any:
+    - pattern: (await fetch($$$FETCH)).text()
+    - pattern: (await fetch($$$FETCH)).json()
+    - pattern: (await fetch($$$FETCH)).arrayBuffer()

--- a/scripts/determinism-rules/rules/no-unbounded-response-read.yml
+++ b/scripts/determinism-rules/rules/no-unbounded-response-read.yml
@@ -1,0 +1,13 @@
+id: no-unbounded-response-read
+language: javascript
+severity: error
+message: Buffering a whole fetch response before checking its size makes the limit advisory; read the body in chunks and cancel once the limit is exceeded.
+note: Stream response.body with a reader, track byte length as chunks arrive, and cancel over-limit streams. Matches by receiver name (response/res/resp); see no-unbounded-inline-fetch-read for inline fetch chains.
+rule:
+  any:
+    - pattern: $RES.text()
+    - pattern: $RES.json()
+    - pattern: $RES.arrayBuffer()
+constraints:
+  RES:
+    regex: (?i)(response|resp|res)$

--- a/scripts/determinism-rules/sgconfig.yml
+++ b/scripts/determinism-rules/sgconfig.yml
@@ -1,0 +1,2 @@
+ruleDirs:
+  - rules

--- a/scripts/ephemeral-canary.mjs
+++ b/scripts/ephemeral-canary.mjs
@@ -1,6 +1,10 @@
 import { randomUUID } from "node:crypto";
 import process from "node:process";
 
+import { readBodyBounded } from "./lib/guardrail-utils.mjs";
+
+const MAX_CANARY_RESPONSE_BYTES = 1024 * 1024;
+
 const serviceOrigin = process.env.CPTV_EPHEMERAL_ORIGIN ?? "https://ephemeral.schalkneethling.com";
 const syntheticHtml =
   '<!doctype html><html lang="en"><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow,noarchive"><title>CPTV compatibility canary</title></head><body><p>Non-sensitive synthetic compatibility canary.</p></body></html>';
@@ -16,9 +20,14 @@ const createResponse = await fetch(new URL("/api/pages", serviceOrigin), {
 
 if (!createResponse.ok)
   throw new Error(
-    `Ephemeral canary upload failed closed: ${createResponse.status} ${await createResponse.text()}`,
+    `Ephemeral canary upload failed closed: ${createResponse.status} ${
+      (await readBodyBounded(createResponse, MAX_CANARY_RESPONSE_BYTES)) ?? "[body exceeded 1 MiB]"
+    }`,
   );
-const created = await createResponse.json();
+const createdBody = await readBodyBounded(createResponse, MAX_CANARY_RESPONSE_BYTES);
+if (createdBody === null)
+  throw new Error("Ephemeral canary upload response exceeded its 1 MiB limit.");
+const created = JSON.parse(createdBody);
 if (typeof created.id !== "string")
   throw new Error("Ephemeral canary response omitted the page ID.");
 
@@ -41,7 +50,8 @@ for (const directive of [
   if (!csp.includes(directive)) failures.push(`missing CSP ${directive}`);
 }
 if (/(^|;)\s*connect-src\s+/u.test(csp)) failures.push("unexpected connect-src override");
-if ((await contentResponse.text()) !== syntheticHtml) failures.push("content bytes changed");
+if ((await readBodyBounded(contentResponse, MAX_CANARY_RESPONSE_BYTES)) !== syntheticHtml)
+  failures.push("content bytes changed");
 
 if (failures.length > 0) {
   throw new Error(`Ephemeral canary failed: ${failures.join(", ")}`);

--- a/scripts/lib/agent-lifecycle.mjs
+++ b/scripts/lib/agent-lifecycle.mjs
@@ -8,8 +8,8 @@ export function run(command, args) {
   if (result.error) {
     throw result.error;
   }
-  if (typeof result.status === "number" && result.status !== 0) {
-    process.exitCode = result.status;
+  if (result.status !== 0) {
+    process.exitCode = typeof result.status === "number" ? result.status : 1;
     return false;
   }
   return true;
@@ -23,6 +23,13 @@ export function runExpectedFailure(command, args) {
   if (result.status === 0) {
     process.stderr.write(
       "RED evidence command passed; it did not prove the selected unmet criterion.\n",
+    );
+    process.exitCode = 1;
+    return false;
+  }
+  if (typeof result.status !== "number") {
+    process.stderr.write(
+      `RED evidence command was terminated by signal ${result.signal}; a crash is not valid RED evidence.\n`,
     );
     process.exitCode = 1;
     return false;

--- a/scripts/lib/guardrail-utils.mjs
+++ b/scripts/lib/guardrail-utils.mjs
@@ -57,7 +57,9 @@ export async function listFiles(root, predicate) {
 
   async function walk(directory) {
     const entries = await readdir(directory, { withFileTypes: true });
-    for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    const byCodeUnit = (left, right) =>
+      left.name < right.name ? -1 : left.name > right.name ? 1 : 0;
+    for (const entry of entries.sort(byCodeUnit)) {
       const candidate = resolve(directory, entry.name);
       if (entry.isDirectory()) {
         await walk(candidate);
@@ -72,6 +74,25 @@ export async function listFiles(root, predicate) {
   }
 
   return files;
+}
+
+export async function readBodyBounded(response, limit) {
+  const reader = response.body.getReader();
+  const chunks = [];
+  let total = 0;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) {
+      break;
+    }
+    total += value.byteLength;
+    if (total > limit) {
+      await reader.cancel();
+      return null;
+    }
+    chunks.push(value);
+  }
+  return Buffer.concat(chunks).toString("utf8");
 }
 
 export function sha256(content) {

--- a/scripts/test/guardrails.test.mjs
+++ b/scripts/test/guardrails.test.mjs
@@ -112,6 +112,99 @@ test("AC-GUARD-006 requires a criterion and explicit RED test command", () => {
   assert.match(result.stderr, /Usage: agent-verify-red/);
 });
 
+test("AC-GUARD-001 rejects a traceability row referencing an undeclared criterion", async () => {
+  await fixture(async (root) => {
+    await mkdir(resolve(root, "docs/acceptance"), { recursive: true });
+    await writeFile(
+      resolve(root, "docs/acceptance/slice.md"),
+      "# Slice\n\n## AC-TEST-001 — Outcome\n\n## Traceability\n\n| Criterion/scenario | Implementation |\n| --- | --- |\n| AC-TEST-001 | `src/a.ts` |\n| AC-TEST-009 | `src/gone.ts` |\n",
+    );
+    const result = run("check-acceptance-traceability.mjs", root);
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /references undeclared criterion AC-TEST-009/);
+  });
+});
+
+test("AC-GUARD-006 rejects a criterion that is not declared in docs/acceptance", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      resolve(repositoryRoot, "scripts/agent-verify-red.mjs"),
+      "--criterion",
+      "AC-UNDEFINED-999",
+      "--",
+      process.execPath,
+      "-e",
+      "process.exit(1)",
+    ],
+    { cwd: repositoryRoot, encoding: "utf8" },
+  );
+  assert.equal(result.status, 2);
+  assert.match(result.stderr, /AC-UNDEFINED-999 is not declared/);
+});
+
+test("AC-GUARD-006 rejects a signal-terminated RED command as evidence", () => {
+  const result = spawnSync(
+    process.execPath,
+    [
+      resolve(repositoryRoot, "scripts/agent-verify-red.mjs"),
+      "--criterion",
+      "AC-GUARD-001",
+      "--",
+      process.execPath,
+      "-e",
+      'process.kill(process.pid, "SIGKILL")',
+    ],
+    { cwd: repositoryRoot, encoding: "utf8" },
+  );
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /terminated by signal SIGKILL/);
+  assert.doesNotMatch(result.stdout, /RED evidence captured/);
+});
+
+test("AC-GUARD-008 reports locale-sensitive sorts and unbounded response reads", async () => {
+  await fixture(async (root) => {
+    await writeFile(
+      resolve(root, "violations.mjs"),
+      [
+        "export const sorted = (entries) =>",
+        "  entries.sort((left, right) => left.name.localeCompare(right.name));",
+        "export async function unbounded(url) {",
+        "  const response = await fetch(url);",
+        "  return response.text();",
+        "}",
+        "export const inline = async (url) => (await fetch(url)).json();",
+        "",
+      ].join("\n"),
+    );
+    const result = spawnSync(
+      process.execPath,
+      [resolve(repositoryRoot, "scripts/check-determinism-rules.mjs"), root],
+      { cwd: repositoryRoot, encoding: "utf8" },
+    );
+    assert.equal(result.status, 1);
+    assert.match(result.stderr, /no-locale-sensitive-sort/);
+    assert.match(result.stderr, /no-unbounded-response-read/);
+    assert.match(result.stderr, /no-unbounded-inline-fetch-read/);
+  });
+});
+
+test("AC-GUARD-008 passes deterministic guardrail code", async () => {
+  await fixture(async (root) => {
+    await writeFile(
+      resolve(root, "clean.mjs"),
+      "export const sorted = (entries) =>\n  entries.sort((left, right) => (left.name < right.name ? -1 : left.name > right.name ? 1 : 0));\n",
+    );
+    const result = spawnSync(
+      process.execPath,
+      [resolve(repositoryRoot, "scripts/check-determinism-rules.mjs"), root],
+      { cwd: repositoryRoot, encoding: "utf8" },
+    );
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Determinism rules passed/);
+  });
+});
+
 test("AC-GUARD-006 rejects a RED command that passes instead of proving an unmet outcome", () => {
   const result = spawnSync(
     process.execPath,


### PR DESCRIPTION
The determinant collection ([PR schalkneethling/determinant#3](https://github.com/schalkneethling/determinant/pull/3)) distilled this repository's guardrails, and review there surfaced defects that exist here too. This PR ports every fix back, following the acceptance-first workflow (boundaries updated → tests verified RED → implementation → GREEN), and adds the deterministic gate that keeps both recurring classes out permanently.

## Ported fixes
- **`guardrail-utils.mjs` `listFiles`**: code-unit filename comparison replaces `localeCompare`, whose order varies with the host locale and ICU data — file order, error order, and derived hashes are now byte-identical across machines.
- **`agent-lifecycle.mjs`**: a signal-terminated child (`status: null`) was previously treated as *success* by `run()` and as valid RED evidence by `runExpectedFailure()`. Now it fails `run()`, and only a numeric nonzero exit counts as RED evidence — a crash is rejected with its own message.
- **`agent-verify-red.mjs`**: the criterion must be declared as a `## AC-…` heading in `docs/acceptance/*.md`; an invented `AC-UNDEFINED-999` exits 2 before anything runs.
- **`check-acceptance-traceability.mjs`**: the Traceability table is isolated up to the next heading and compared bidirectionally — declared criteria missing from the table (unchanged exact-once count) and stale rows referencing undeclared criteria both fail. The real five acceptance documents pass the tightened gate.
- **Bounded streaming reads** via a shared `readBodyBounded` helper: `check-spec-links`, `check-spec-drift`, `check-supported-syntax-names` (which previously had **no** size limit), `check-ephemeral-drift`, and `ephemeral-canary` now consume bodies in chunks and cancel the stream the moment their limit is exceeded, instead of buffering the full body and measuring afterwards.

## New gate: AC-GUARD-008 (`guardrails:determinism`)
`check-determinism-rules.mjs` runs pinned `@ast-grep/cli@0.45.3` (exact-version dev dependency) over `scripts/` with three structural rules: no `localeCompare` comparators, no `.text()/.json()/.arrayBuffer()` on response-suffixed receivers, no inline `(await fetch(...))` reads. Wired into `check:contracts`. Proof it earns its keep: the first run immediately flagged the two ephemeral scripts, which drove those fixes. The receiver rule uses a case-insensitive **suffix** match, so `createResponse`/`contentResponse`/`proposedCommitResponse` are covered.

## Acceptance & verification
- `AC-GUARD-001` and `AC-GUARD-006` boundaries extended; `AC-GUARD-008` added with contract-table and traceability rows.
- Five new guardrail tests were confirmed RED before implementation and are GREEN after; all 15 pass.
- Full `pnpm run check` passes (format, typecheck, tests, build, all contract gates including the new one).
- Live runs: spec links (5 references) and spec drift pass with streamed reads; the ephemeral canary passes end-to-end.

## ⚠️ Genuine drift finding (not fixed here, per the notify-don't-autofix contract)
`check-ephemeral-drift` now correctly reports that the pinned blob for `netlify/functions/pages.ts` (`b983299…`) no longer matches Ephemeral Pages `main` (`20d486b…`). The canary still passes, so effective delivery behavior is unchanged — but the pin deserves your review.

Out of scope, flagged for a future decision: `localeCompare` sorts also exist in product package sources (`packages/{cli,core,report,stylelint}`), where audit-JSON ordering is a documented determinism contract; changing those alters canonical output and deserves its own acceptance slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTpWu13xpEVfU2q8vn9faM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated checks for deterministic sorting and bounded network-response handling.
  - Added clearer validation for acceptance-criterion traceability and verification inputs.
- **Bug Fixes**
  - Prevented oversized responses from being processed without limits.
  - Improved handling of nonzero exit statuses and rejected signal-terminated verification as invalid evidence.
- **Documentation**
  - Expanded acceptance guardrails, contract coverage, and traceability requirements.
- **Tests**
  - Added coverage for new validation, determinism, response-size, and verification scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->