### PR TITLE
Update Ephemeral Pages pin to the MCP-server release

### DIFF
--- a/.bumpy/ephemeral-mcp-release-pin.md
+++ b/.bumpy/ephemeral-mcp-release-pin.md
@@ -1,0 +1,5 @@
+---
+"@schalkneethling/css-property-type-validator-cli": patch
+---
+
+Update the pinned Ephemeral Pages compatibility contract to the MCP-server release; the reviewed delivery behavior is unchanged.

--- a/compatibility/ephemeral-pages.json
+++ b/compatibility/ephemeral-pages.json
@@ -3,8 +3,8 @@
   "compatibilityVersion": "1.0",
   "upstream": {
     "repository": "https://github.com/schalkneethling/ephemeral-pages",
-    "commit": "5bee37aaed30985a1bb4c7ebc62d6acecd772002",
-    "checkedAt": "2026-08-08",
+    "commit": "9b11df2a1f9b8b4ea05c74034e5c76f6a5a0841d",
+    "checkedAt": "2026-09-01",
     "sources": [
       {
         "path": "src/csp.ts",
@@ -20,7 +20,7 @@
       },
       {
         "path": "netlify/functions/pages.ts",
-        "blobSha": "b9832998a1799b5ba832dfb5496c1477b0fa8f71"
+        "blobSha": "20d486bb562953a2665f78d71d6c6fafa51827cd"
       }
     ]
   },

--- a/contracts/generated-contracts.json
+++ b/contracts/generated-contracts.json
@@ -2,7 +2,7 @@
   "contracts": [
     {
       "path": "packages/cli/src/ephemeral-contract.generated.ts",
-      "sha256": "241b2b4be11694f7729f62fec00c9a7828299e527874c41cd0b33d8a779ec622"
+      "sha256": "3e7c1f2cdee1d0e24f5046cf66777f05ca757cefa630da7c32096fd8fd909ba2"
     }
   ]
 }

--- a/packages/cli/src/ephemeral-contract.generated.ts
+++ b/packages/cli/src/ephemeral-contract.generated.ts
@@ -6,8 +6,8 @@ export const EPHEMERAL_PAGES_CONTRACT = {
   "compatibilityVersion": "1.0",
   "upstream": {
     "repository": "https://github.com/schalkneethling/ephemeral-pages",
-    "commit": "5bee37aaed30985a1bb4c7ebc62d6acecd772002",
-    "checkedAt": "2026-08-08",
+    "commit": "9b11df2a1f9b8b4ea05c74034e5c76f6a5a0841d",
+    "checkedAt": "2026-09-01",
     "sources": [
       {
         "path": "src/csp.ts",
@@ -23,7 +23,7 @@ export const EPHEMERAL_PAGES_CONTRACT = {
       },
       {
         "path": "netlify/functions/pages.ts",
-        "blobSha": "b9832998a1799b5ba832dfb5496c1477b0fa8f71"
+        "blobSha": "20d486bb562953a2665f78d71d6c6fafa51827cd"
       }
     ]
   },


### PR DESCRIPTION
Resolves the drift reported by `check-ephemeral-drift` (surfaced while working on #200): upstream `main` (`9b11df2`) is 41 commits ahead of the pinned `5bee37a`, primarily adding the hosted MCP server.

## Review of the drift (per the notify-don't-autofix contract)
- Of the four pinned delivery sources, **only `netlify/functions/pages.ts` changed** (+7/−26); `src/csp.ts`, `src/domain.ts`, and `netlify/functions/html-validation.ts` blobs are identical.
- The `pages.ts` diff is behavior-identical refactoring, verified against the extracted modules at the new commit:
  - the Netlify edge rate limit moved to `src/constants.ts` with the **same** `60`-second window / `120`-request values and `["ip", "domain"]` aggregation;
  - `resolvePublicBaseUrl` and the `/p/{id}` URL construction moved to `src/public-url.ts` unchanged.
- No delivery-contract field (CSP, viewer sandbox, `nosniff`/`noindex` headers, upload limits, TTLs) is affected.

## Changes
- `compatibility/ephemeral-pages.json`: commit → `9b11df2`, `pages.ts` blob → `20d486b`, `checkedAt` → 2026-09-01.
- `packages/cli/src/ephemeral-contract.generated.ts` regenerated via `generate-ephemeral-contract.mjs --write`; digest refreshed in `contracts/generated-contracts.json`.

## Verification
- `check-ephemeral-contract`, `check-generated-contracts --require`, and the generate-mode staleness check all pass.
- Live: `check-ephemeral-drift` reports main matching the pinned blobs; the synthetic canary passes end-to-end (nosniff, noindex, all five CSP directives, no `connect-src`, byte-identical content).
- Full `pnpm run check` green.

Worth a thought (not done here): `pages.ts` now imports `src/constants.ts` and `src/public-url.ts`, so a slice of delivery-adjacent behavior lives outside the pinned file set. If you want drift coverage for those, add them to `upstream.sources`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QTpWu13xpEVfU2q8vn9faM

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated compatibility verification metadata.
  * Refreshed generated contract integrity information.
  * Added a patch-level release pin to document MCP server compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->